### PR TITLE
ajout test sites sur rapport de désinfo

### DIFF
--- a/plugin/plugin_chrome/releases/Plugin-dima/data/databases/Baybridge.js
+++ b/plugin/plugin_chrome/releases/Plugin-dima/data/databases/Baybridge.js
@@ -1,0 +1,769 @@
+// DIMA - Base de données de l'infrastructure BAYBRIDGE
+// Opération d'influence chinoise ciblant des audiences étrangères via des sociétés de marketing digital
+// Sources: Tadaweb & Paul Charon, Focus Report 2025
+/**
+ * OPÉRATION BAYBRIDGE
+ * ===================
+ * 
+ * Description: Vaste écosystème d'influence informationnelle chinoise opéré depuis la région 
+ * de Greater Bay Area (Guangdong). L'infrastructure technique combine des campagnes de 
+ * marketing digital avec de la manipulation informationnelle ciblant des dizaines de pays.
+ * 
+ * Acteurs principaux:
+ * - Shenzhen Haimai Yunxiang Media Co., Ltd. (深圳市海卖云享传媒有限公司)
+ * - Shanghai Haixun Technology Co., Ltd (海讯社文化传播有限公司)
+ * 
+ * Caractéristiques:
+ * - Création de centaines de sites d'information inauthentiques
+ * - Diffusion de contenu aligné avec Pékin et Moscou
+ * - Narratives contradictoires: "positive energy" chinoise + propagande pro-Kremlin
+ * - Traductions de mauvaise qualité, absence de supervision éditoriale
+ * - Inefficacité remarquable malgré une infrastructure technique sophistiquée
+ * 
+ * Date d'identification: 2025
+ * Pays ciblés: USA, Europe, Asie, Amérique Latine, Afrique
+ */
+
+const baybridgeDomains = [
+  
+  // ===== ENTITÉS COMMERCIALES PRINCIPALES =====
+  
+  {
+    domain: "haipress.com",
+    matchType: "exact",
+    reason: "Site commercial principal de Shanghai Haixun Technology Co. Ltd., proposant des services de distribution de contenu à l'international",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Marketing-Digital",
+      "Sites-Commerciaux",
+      "Haixun"
+    ]
+  },
+
+  {
+    domain: "hmedium.com",
+    matchType: "exact",
+    reason: "Site commercial principal de Haimai, proposant 'increase the value of your brand'. Interface client pour services de marketing",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Marketing-Digital",
+      "Sites-Commerciaux",
+      "Haimai"
+    ]
+  },
+
+  {
+    domain: "hmedium.net",
+    matchType: "exact",
+    reason: "Site commercial de Haimai hébergeant les offres commerciales détaillées (packages ciblant audiences étrangères)",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Marketing-Digital",
+      "Sites-Commerciaux",
+      "Haimai"
+    ]
+  },
+
+  {
+    domain: "haixunpress.com",
+    matchType: "exact",
+    reason: "Site commercial principal de Haixun. Lien d'infrastructure avec sihaimai.com (IP 47.91.170.222, jan-oct 2024)",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Marketing-Digital",
+      "Sites-Commerciaux",
+      "Haixun"
+    ]
+  },
+
+  {
+    domain: "sihaimai.com",
+    matchType: "exact",
+    reason: "Infrastructure de services d'hébergement et de dissémination liée à Haimai. Lien technique avec haixunpress.com",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Hébergement",
+      "Haimai"
+    ]
+  },
+
+  {
+    domain: "aisugao.com",
+    matchType: "exact",
+    reason: "Plateforme de marketing de marque pilotée par IA de Haixun, offrant traduction automatique d'articles via LLMs natifs",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2024-04-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "LLM",
+      "IA-Générative",
+      "Haixun",
+      "Infrastructure"
+    ]
+  },
+
+  {
+    domain: "ebuypress.com",
+    matchType: "exact",
+    reason: "Site de distribution de contenu (content provider) lié à Haixun. API payante disponible: api.haipress.com/api/media/resources",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Distribution-Contenu",
+      "Haixun"
+    ]
+  },
+
+  {
+    domain: "globerelease.com",
+    matchType: "exact",
+    reason: "Premier site enregistré par Haimai, affichant contenu générique distribué sur de nombreux autres sites de l'écosystème",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Distribution-Contenu",
+      "Haimai"
+    ]
+  },
+
+  {
+    domain: "shiworld.cn",
+    matchType: "contains",
+    reason: "Site d'hébergement lié à Haimai. Contient news.shiworld.cn hébergeant packages commerciaux",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Hébergement",
+      "Haimai"
+    ]
+  },
+
+  {
+    domain: "mlzgb.cn",
+    matchType: "exact",
+    reason: "Site d'hébergement des packages commerciaux de Haimai (fichiers Excel, liens directs). 92% des packages Haimai hébergés ici",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Infrastructure",
+      "Hébergement",
+      "Haimai"
+    ]
+  },
+
+  // ===== FOURNISSEURS DE CONTENU (CONTENT PROVIDERS) =====
+  
+  {
+    domain: "timesnewswire.com",
+    matchType: "exact",
+    reason: "Principal fournisseur de contenu du réseau (13% des articles). Diffuse communiqués de presse + contenu propagande (CGTN, Global Times)",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Distribution-Contenu",
+      "Propagande",
+      "Positive-Energy"
+    ]
+  },
+
+  {
+    domain: "updatenews.info",
+    matchType: "exact",
+    reason: "PRINCIPAL fournisseur de contenu (77% des articles sur sites finaux). Diffuse massivement narratives pro-Kremlin + contenu chinois",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "critical",
+    tags: [
+      "BAYBRIDGE",
+      "Russie",
+      "Chine",
+      "Distribution-Contenu",
+      "Propagande-Pro-Kremlin",
+      "Ukraine",
+      "LLM-Intoxication"
+    ]
+  },
+
+  {
+    domain: "meijiedaka.com",
+    matchType: "exact",
+    reason: "Fournisseur de contenu identifié dans l'écosystème, alimentant sites finaux de Haimai",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Distribution-Contenu"
+    ]
+  },
+
+  // ===== SITES FINAUX - FRANCE (Package "Propagande Politique") =====
+  
+  {
+    domain: "alpsbiz.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Diffuse contenu pro-Kremlin + narratives chinoises contradictoires",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "rmtcityfr.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Traductions de mauvaise qualité, erreurs grammaticales multiples",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "provencedaily.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Amplifie narratives pro-Kremlin, cite TASS, RIA Novosti",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "louispress.org",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Usurpation d'identité (naming convention trompeur). Hébergé cluster FR",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Usurpation-Identité",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "friendlyparis.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France ('Paris Amical'). Fautes d'orthographe, images manquantes",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "eiffelpost.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Republie articles CGTN + contenu pro-Kremlin. Faible qualité éditoriale",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Positive-Energy",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "fr.wdpp.org",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Sous-domaine spécifique audience francophone",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "fr.euleader.org",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Version francophone de euleader.org",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Sites-UE",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "fftribune.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Naming convention mimant média légitime",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Usurpation-Identité",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "economyfr.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Focus thématique économie",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "froneplus.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Contenu synchronisé avec autres sites du réseau",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "frnewsfeed.com",
+    matchType: "exact",
+    reason: "Site final du package 'Propagande Politique' France. Publication synchronisée, architecture similaire Jeecg-Boot",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-France",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  // ===== SITES FINAUX - AUTRES PAYS EUROPÉENS =====
+  
+  {
+    domain: "euleader.org",
+    matchType: "exact",
+    reason: "Site ciblant audience UE. Diffuse contenu BTS, actualités Shenzhen, narratives pro-Kremlin. Exemple: article BTS 27/05/2025",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-UE",
+      "Propagande",
+      "Anti-Ukraine"
+    ]
+  },
+
+  {
+    domain: "londonclup.com",
+    matchType: "exact",
+    reason: "Site package UK. Contenu en vietnamien par erreur (exemple page d'accueil 08/07/2025), images manquantes",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-UK",
+      "Propagande"
+    ]
+  },
+
+  // ===== SITES FINAUX - RUSSIE =====
+  
+  {
+    domain: "findmoscow.com",
+    matchType: "exact",
+    reason: "Site ciblant audience russe ('Найти Москву'). Hébergé sur cluster serveur russe avec sites ciblant Russie",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-Russie",
+      "Propagande"
+    ]
+  },
+
+  {
+    domain: "ekaterintech.com",
+    matchType: "exact",
+    reason: "Site ciblant audience russe. Hébergé IP 18.171.181.70 avec cluster sites RU. Lien avec louispress.org (même IP FR)",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Russie",
+      "Sites-Russie",
+      "Infrastructure"
+    ]
+  },
+
+  // ===== SITES FINAUX - AUSTRALIE =====
+  
+  {
+    domain: "capitalsydney.com",
+    matchType: "exact",
+    reason: "Site ciblant audience australienne ('Sydney News'). Naming convention usurpation identité",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Sites-Australie",
+      "Usurpation-Identité"
+    ]
+  },
+
+  // ===== EXEMPLES TYPOSQUATTING =====
+  
+  {
+    domain: "dertagesspiegel.com",
+    matchType: "exact",
+    reason: "Typosquatting de 'Der Tagesspiegel' (journal allemand). Site identifié dans packages commerciaux",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Sites-Allemagne",
+      "Usurpation-Identité",
+      "Typosquatting"
+    ]
+  },
+
+  {
+    domain: "nrchandelsblad.com",
+    matchType: "exact",
+    reason: "Typosquatting de 'NRC Handelsblad' (journal néerlandais). Site identifié dans packages commerciaux",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Sites-Pays-Bas",
+      "Usurpation-Identité",
+      "Typosquatting"
+    ]
+  },
+
+  {
+    domain: "kanagawa-ken.com",
+    matchType: "exact",
+    reason: "Typosquatting ciblant audience japonaise. Site identifié dans packages commerciaux",
+    source: "Tadaweb & Paul Charon - Focus BAYBRIDGE 2025",
+    reportUrl: "https://www.tadaweb.com/hub/68e3e66e4f7350000150899b",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: [
+      "BAYBRIDGE",
+      "Chine",
+      "Sites-Japon",
+      "Usurpation-Identité",
+      "Typosquatting"
+    ]
+  }
+
+];
+
+// =============================================================================
+// FONCTIONS UTILITAIRES
+// =============================================================================
+
+// Filtrer par tag
+function filterBaybridgeByTag(tag) {
+  return baybridgeDomains.filter(d => d.tags.includes(tag));
+}
+
+// Filtrer par niveau de risque
+function filterBaybridgeByRiskLevel(level) {
+  return baybridgeDomains.filter(d => d.riskLevel === level);
+}
+
+// Obtenir tous les tags uniques
+function getBaybridgeTags() {
+  const allTags = new Set();
+  baybridgeDomains.forEach(d => {
+    d.tags.forEach(tag => allTags.add(tag));
+  });
+  return Array.from(allTags).sort();
+}
+
+// Obtenir les statistiques
+function getBaybridgeStats() {
+  return {
+    total: baybridgeDomains.length,
+    critical: baybridgeDomains.filter(d => d.riskLevel === "critical").length,
+    highRisk: baybridgeDomains.filter(d => d.riskLevel === "high").length,
+    mediumRisk: baybridgeDomains.filter(d => d.riskLevel === "medium").length,
+    lowRisk: baybridgeDomains.filter(d => d.riskLevel === "low").length,
+    tags: getBaybridgeTags()
+  };
+}
+
+// Obtenir sites par catégorie
+function getBaybridgeByCategory() {
+  return {
+    infrastructure: filterBaybridgeByTag("Infrastructure"),
+    contentProviders: filterBaybridgeByTag("Distribution-Contenu"),
+    france: filterBaybridgeByTag("Sites-France"),
+    russia: filterBaybridgeByTag("Sites-Russie"),
+    uk: filterBaybridgeByTag("Sites-UK"),
+    propaganda: filterBaybridgeByTag("Propagande"),
+    typosquatting: filterBaybridgeByTag("Typosquatting")
+  };
+}
+
+// =============================================================================
+// EXPORTS ET DISPONIBILITÉ GLOBALE
+// =============================================================================
+
+// Export pour Node.js / modules
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    baybridgeDomains,
+    filterBaybridgeByTag,
+    filterBaybridgeByRiskLevel,
+    getBaybridgeTags,
+    getBaybridgeStats,
+    getBaybridgeByCategory
+  };
+}
+
+// Disponibilité globale pour le navigateur
+if (typeof window !== 'undefined') {
+  window.baybridgeDomains = baybridgeDomains;
+  window.baybridgeUtils = {
+    filterByTag: filterBaybridgeByTag,
+    filterByRiskLevel: filterBaybridgeByRiskLevel,
+    getTags: getBaybridgeTags,
+    getStats: getBaybridgeStats,
+    getByCategory: getBaybridgeByCategory
+  };
+}
+
+// Log de chargement
+console.log(`Liste BAYBRIDGE chargée: ${baybridgeDomains.length} domaines identifiés`);
+if (baybridgeDomains.length > 0) {
+  console.log("Statistiques BAYBRIDGE:", getBaybridgeStats());
+  console.log("Catégories:", getBaybridgeByCategory());
+}
+
+// =============================================================================
+// NOTES IMPORTANTES SUR L'OPÉRATION
+// =============================================================================
+
+/**
+ * CONTEXTE GÉOPOLITIQUE:
+ * 
+ * Acteurs identifiés:
+ * - Wu Yanni (吴燕妮): Chercheur SZAS, membre du Comité de propagande municipale de Shenzhen,
+ *   directrice exécutive Haimai Yunxiang Media
+ * - Zhu Haisong (朱海松): Expert en marketing, chercheur, PDG Haixun, liens avec le 
+ *   Département de propagande du Guangdong
+ * 
+ * Caractéristiques techniques:
+ * - Infrastructure partagée entre Haimai et Haixun (IP 47.91.170.222)
+ * - 24% d'overlap dans les offres commerciales internationales (104 packages communs)
+ * - Utilisation de Jeecg-Boot pour génération automatique de sites web
+ * - API Haixun: api.haipress.com/api/media/resources
+ * - Traduction IA via aisugao.com (LLMs natifs)
+ * 
+ * Pays principalement ciblés:
+ * - USA (6% des packages, cible #1)
+ * - Asie du Sud-Est (Corée du Sud, Inde, Vietnam, Thaïlande, Japon, Taiwan)
+ * - Europe: UK (21 packages), Espagne (20), Italie (18), Portugal (17), France (15), Allemagne (15)
+ * 
+ * Narratives diffusées:
+ * 1. Contenu chinois "positive energy" (< 5% du volume):
+ *    - Republication CGTN, Global Times
+ *    - Focus: harmony, win-win cooperation, innovation, développement durable
+ *    - Vocabulaire récurrent: "innovation" (68%), "transformation" (54%), "leadership" (47%)
+ * 
+ * 2. Contenu pro-Kremlin (volume dominant):
+ *    - Sources: TASS, RIA Novosti, RT, Tsargrad TV, Rambler.ru
+ *    - Focus: guerre Ukraine, anti-OTAN, amplification Florian Philippot
+ *    - Channels Telegram: Maria Zakharova, Alexey Pushkov
+ *    - Similarités avec réseau Portal Kombat / Pravda
+ * 
+ * Inefficacité opérationnelle:
+ * - Traductions automatiques de très mauvaise qualité
+ * - Narratives contradictoires (Chine positive vs. Russie agressive)
+ * - Aucune traction sur réseaux sociaux (SimilarWeb: pas de données)
+ * - Système en boucle fermée (sites s'auto-citent)
+ * - Erreurs techniques: encodage cyrillique raté (oct 2024 - fév 2025)
+ * - Contenu vietnamien sur sites UK, images manquantes
+ * 
+ * Risque LLM:
+ * - Infrastructure potentiellement utilisée pour "intoxiquer" les LLMs
+ * - Contournement sanctions médias russes (RT, Sputnik) via "laundering machine"
+ * - Aucune preuve directe d'assimilation par ChatGPT/Copilot/Gemini/DeepSeek (avril 2025)
+ * 
+ * Date pivot: 09 mars 2024
+ * Apparition massive contenu pro-Kremlin sur updatenews.info (hors catégorie TimesNewsWire)
+ * Hypothèse: appropriation infrastructure chinoise par acteurs russes
+ * 
+ * Connexion Portal Kombat:
+ * - Similarités narratives et sources avec réseau "Pravda"
+ * - Pas de lien technique formel établi
+ * - Exemple: même citation Philippot sur updatenews.info (05/01/25) et 
+ *   france.news-pravda.com (06/01/25)
+ */

--- a/plugin/plugin_chrome/releases/Plugin-dima/data/databases/Copycop.js
+++ b/plugin/plugin_chrome/releases/Plugin-dima/data/databases/Copycop.js
@@ -1,0 +1,2101 @@
+// Liste des domaines liés à l'opération CopyCop
+// Source: Recorded Future - CTA-RU-2025-0917
+// Date du rapport: 17 septembre 2025
+
+/* 
+ * DOCUMENTATION DES TAGS
+ * =====================
+ * 
+ * Tags obligatoires (présents sur tous les domaines):
+ * - CopyCop: Indique l'appartenance à l'opération CopyCop
+ * - Russie: Origine russe de l'opération
+ * 
+ * Tags de catégorie (type de site):
+ * - Sites-US: Sites fictifs ciblant les États-Unis
+ * - Sites-France: Sites fictifs ciblant la France
+ * - Sites-Canada: Sites fictifs ciblant le Canada
+ * - Truefact: Réseau de faux sites de fact-checking multi-langues
+ * - Infrastructure: Serveurs techniques et outils (LLM, hébergement)
+ * 
+ * Tags géographiques (pays ciblé ou mentionné):
+ * - USA, France, Canada, Arménie, Moldova, Ukraine
+ * - Allemagne, Turquie, Afrique, Espagne, Mexique
+ * 
+ * Tags thématiques (objectif ou méthode):
+ * - Anti-Ukraine: Contenu hostile à l'Ukraine
+ * - Élections: Tentatives d'ingérence électorale
+ * - Désinformation-Ciblée: Campagnes de désinformation précises
+ * - Usurpation-Identité: Imitation de médias légitimes
+ * - LLM: Infrastructure de génération de contenu par IA
+ * - Dougan: Lié à John Mark Dougan personnellement
+ * - Multi-Langues: Contenu publié en plusieurs langues
+ * - Parodie: Sites parodiques (ex: NewsGuard)
+ * - Anti-Fact-Checking: Ciblant les organisations de vérification
+ * 
+ * Tags linguistiques:
+ * - Swahili: Contenu en swahili
+ */
+
+const copycopDomains = [
+  // ===== SITES US =====
+  {
+    domain: "allstatesnews.us",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "alohadigest.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "bayoucitycrier.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "bayoucitytoday.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, contient des artefacts LLM révélant l'utilisation d'IA pour générer du contenu",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "capitalcitydaily.com",
+    matchType: "exact",
+    reason: "Site fictif utilisé pour diffuser des vidéos de désinformation, notamment sur Rumble, accusant l'Ukraine de vendre des armes aux cartels mexicains",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "capitoldaily.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "dailyweekly.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "fldaily.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "flga.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "goldengatedaily.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "kjfk.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "klas.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "klax.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "kmia.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "kpbi.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "kphl.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "ksfo.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "ksmo.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "lachronicle.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "lareport.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "metroreport.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "sfreport.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "silvercity.news",
+    matchType: "exact",
+    reason: "Site utilisé pour publier de fausses informations sur des attaques russes planifiées contre l'Ukraine, contenant des artefacts LLM",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "steelcitydaily.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "twincityreport.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "txdaily.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "usatimes.news",
+    matchType: "exact",
+    reason: "Site utilisé pour amplifier de fausses accusations contre Zelensky concernant des paiements à des journalistes",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "walx.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "wdmdtv.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "windycitycrier.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "windycitymirror.com",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "windycitytimes.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "wktv.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "wtat.news",
+    matchType: "exact",
+    reason: "Site fictif impersonant un média local américain, utilisé pour diffuser du contenu pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "USA", "Sites-US", "Anti-Ukraine"]
+  },
+  {
+    domain: "wval.news",
+    matchType: "exact",
+    reason: "Site utilisé pour publier de fausses informations sur des attaques russes planifiées contre l'Ukraine",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-29",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie"]
+  },
+
+  // ===== RÉSEAU TRUEFACT =====
+  {
+    domain: "truefact.news",
+    matchType: "exact",
+    reason: "Domaine principal d'un réseau de sites fictifs se faisant passer pour une organisation de fact-checking, publiant en turc, ukrainien et swahili",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues"]
+  },
+  {
+    domain: "africa.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact publiant en swahili sous le nom 'Habari Afrika', première expansion de CopyCop vers l'Afrique",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "Afrique", "Swahili"]
+  },
+  {
+    domain: "de.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact ciblant l'Allemagne, partie du réseau de désinformation CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "Allemagne"]
+  },
+  {
+    domain: "fr.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact miroir de franceencolere.fr, ciblant les audiences françaises",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "France"]
+  },
+  {
+    domain: "france.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact miroir de veritecachee.fr, ciblant les audiences françaises",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "France"]
+  },
+  {
+    domain: "germany.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact hébergé sur infrastructure russe liée à John Mark Dougan",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "Allemagne"]
+  },
+  {
+    domain: "mexico.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact ciblant le Mexique, expansion de CopyCop en Amérique latine",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "Mexique"]
+  },
+  {
+    domain: "spain.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact ciblant l'Espagne, expansion de CopyCop vers les audiences hispanophones",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "Espagne"]
+  },
+  {
+    domain: "turkey.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact publiant en turc, première expansion de CopyCop vers la Turquie",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "Turquie"]
+  },
+  {
+    domain: "ukraine.truefact.news",
+    matchType: "exact",
+    reason: "Sous-domaine Truefact publiant en ukrainien et français, ciblant directement l'Ukraine",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Truefact", "Multi-Langues", "Ukraine", "Anti-Ukraine"]
+  },
+
+  // ===== SITES FRANÇAIS (partie 1/3) =====
+  {
+    domain: "actu-net.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actualite360.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actualitesmaintenant.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actualitespourtous.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actualitespourtous.fr.expressactus.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actubretagne.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local breton, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actudirecte.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actuiledefrance.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média d'Île-de-France, faisant partie du système de sous-domaines miroirs",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actuiledefrance.fr.nouvelle-aquitaine-aujourdhui.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actuperspectives.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actus-independantes.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actus-independantes.fr.meilleuresactus.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actus-sanscensure.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actus-sanscensure.fr.infos-encontinu.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actus24.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actusetinfosdupays.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "actusetinfosdupays.fr.frmedialive.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "affichedujour.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "agorahexagone.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "ame-nationale.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "ame-nationale.fr.savoirtout.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "analyse-actus.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "analyse-actus.fr.pause-actus.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "ardennesinfolive.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local des Ardennes, faisant partie du système de sous-domaines miroirs",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "ardennesinfolive.fr.vosges-enligne.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "bref-france24.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "bref-france24.fr.visiondelafrance.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "chroniquesfrancaises.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "chronoinfo.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "courrierfrance24.fr",
+    matchType: "exact",
+    reason: "Site fictif utilisé pour diffuser de fausses informations sur Orano et l'Arménie avec des vidéos de qualité professionnelle",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "direct-nouvelles.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "direct-nouvelles.fr.meilleuresactus.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "echorhonealpes.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local de Rhône-Alpes, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "eclairinfo.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+
+  // ===== SITES FRANÇAIS (partie 2/3) =====
+  {
+    domain: "editorialesactus.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "editorialesactus.fr.francechronique.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "enquetedujour.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "evenementsetactus.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "evenementsetactus.fr.patrimoineinfo.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "expressactus.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "flash-actualites.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "flash-actualites.fr.francechronique.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "flash-bourgognefranchecomte.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local de Bourgogne-Franche-Comté, faisant partie du système de sous-domaines miroirs",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "flash-bourgognefranchecomte.fr.nouvelle-aquitaine-aujourdhui.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "flashhexagone.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "france-aujourdhui.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "france-aujourdhui.fr.actus24.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "france-droite.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "france-droite.fr.patrimoineinfo.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "france-premiere.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "france-vision.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "france24-7.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "france24actus.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "franceactuelle.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "franceactuweb.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "franceactuweb.fr.vivezlinfo.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "franceavanttout.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "franceavanttout.fr.infosdupays.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "francechronique.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "francedetail.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "francepatriotique.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "francepatriotique.fr.chronoinfo.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "francepourlesfrancais.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "francepourlesfrancais.fr.infosdupays.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "francerealites.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "frmedialive.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "info-grand-est.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local du Grand Est, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "info-minute.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "infofrancaisedujour.fr",
+    matchType: "exact",
+    reason: "Site utilisé pour diffuser de fausses accusations contre Pashinyan concernant l'utilisation de fonds français pour acheter une villa",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "infofrance-focus.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "infohexagone.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "infohexagone.fr.actus24.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "infos-encontinu.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "infosdupays.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+
+  // ===== SITES FRANÇAIS (partie 3/3) =====
+  {
+    domain: "infosinternationales.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "infosinternationales.fr.visiondelafrance.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "instantactus.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "investigateurfrancophone.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "journalrepublicain.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "la-francegaullienne.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "la-francegaullienne.fr.frmedialive.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lactualite-provencale.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local provençal, faisant partie du système de sous-domaines miroirs",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lactualite-provencale.fr.info-grand-est.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lafrance-debout.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lafrance-debout.fr.infos-encontinu.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lafrancesouveraine.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lafrancesouveraine.fr.savoirtout.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "latribunefrancaise.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "le-choinfo.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lefilactualites.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lefilhexagonal.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lefocus-occitanie.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local d'Occitanie, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lejournalfrancophone.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lejournalnormand.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local normand, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lepointnumerique.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "lequotidienfrancais.fr",
+    matchType: "exact",
+    reason: "Site utilisé pour diffuser de fausses informations sur des mandats d'arrêt contre des leaders de droite français, incluant de fausses captures WhatsApp",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "linformateurdujour.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "linformateurdujour.fraffichedujour.fr",
+    matchType: "exact",
+    reason: "Erreur de formatage probable dans le rapport - domaine combiné",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "magazinedusoir.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "meilleuresactus.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "midi-pyreneesactualite.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local de Midi-Pyrénées, faisant partie du système de sous-domaines miroirs",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "midi-pyreneesactualite.fr.vosges-enligne.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "minutedinfo.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "miroirdelafrance.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "nordactuquotidien.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local du Nord, faisant partie du système de sous-domaines miroirs",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "nordactuquotidien.fr.normandie-actusinfos.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "normandie-actusinfos.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local normand, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "nouvelle-aquitaine-aujourdhui.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local de Nouvelle-Aquitaine, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "nouvelleperspective.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "nouvelles-deshautsdefrance.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local des Hauts-de-France, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "nouvelles-hexagonales.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "nouvellesfrance24.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "nouvellesfrance24.fr.chronoinfo.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "panorama-info.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "panorama-info.fr.chroniquesfrancaises.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "partiroyaliste.fr",
+    matchType: "exact",
+    reason: "Site se faisant passer pour un parti politique royaliste français, probablement pour cibler les éléments monarchistes marginaux anti-UE et anti-républicains",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2024-08-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "patrimoineinfo.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "pause-actus.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "perspectives-francaises.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "pointdevueactu.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "reportagesinternationaux.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "reportagesinternationaux.fr.pause-actus.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "reseauavecactus.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "reseauavecactus.fr.lefilactualites.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "revelationdes-mensonges.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "revelationdes-mensonges.fr.infosdupays.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "savoirtout.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "sudouestdirect.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local du Sud-Ouest, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "tvfrance2.fr",
+    matchType: "exact",
+    reason: "Site usurpant l'identité de France Télévisions, utilisé pour diffuser de fausses informations sur la vente d'EDF à l'Ukraine",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-22",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "visiondelafrance.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "visionfrancophone.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "visionfrancophone.fr.expressactus.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "vivezlinfo.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "voix-francophone.fr",
+    matchType: "exact",
+    reason: "Site fictif français faisant partie du système de sous-domaines miroirs de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "voix-francophone.fr.lefilactualites.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "voixdelafrance.fr",
+    matchType: "exact",
+    reason: "Site fictif français publiant du contenu généré par IA pro-russe et anti-ukrainien",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "vosges-enligne.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local des Vosges, publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "xn--actu-auvergne-rhne-alpes-lnc.fr",
+    matchType: "exact",
+    reason: "Site fictif se faisant passer pour un média local d'Auvergne-Rhône-Alpes (avec caractères spéciaux encodés), publiant du contenu généré par IA",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-02-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+  {
+    domain: "xn--actu-auvergne-rhne-alpes-lnc.fr.normandie-actusinfos.fr",
+    matchType: "exact",
+    reason: "Sous-domaine miroir combinant deux sites CopyCop pour améliorer la résilience du réseau",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "France", "Sites-France"]
+  },
+
+  // ===== SITES CANADIENS =====
+  {
+    domain: "albertaseparatist.com",
+    matchType: "exact",
+    reason: "Site se faisant passer pour un mouvement séparatiste albertain, avec comptes TikTok et YouTube associés, exploitant les tensions fédérales canadiennes",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-05-02",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Canada", "Sites-Canada"]
+  },
+  {
+    domain: "torontojournal.ca",
+    matchType: "exact",
+    reason: "Site fictif canadien utilisé pour promouvoir du contenu ciblant le chancelier allemand Friedrich Merz",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2024-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Canada", "Sites-Canada"]
+  },
+
+  // ===== AUTRES SITES =====
+  {
+    domain: "newsguard.tech",
+    matchType: "exact",
+    reason: "Site parodique ciblant l'organisation de fact-checking NewsGuard, qui a nommé Dougan 'Disinformer of the Year 2024'",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-07",
+    riskLevel: "medium",
+    tags: ["CopyCop", "Russie", "Parodie", "Anti-Fact-Checking"]
+  },
+  {
+    domain: "insider.eu.com",
+    matchType: "exact",
+    reason: "Site utilisant des sous-domaines pour usurper l'identité de médias, utilisé pour diffuser de fausses accusations contre Maia Sandu concernant des détournements de fonds USAID",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-05-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Moldova", "Élections", "Désinformation-Ciblée"]
+  },
+  {
+    domain: "ndc.eu.com",
+    matchType: "exact",
+    reason: "Site utilisant des sous-domaines pour créer du contenu inauthentique ciblant l'UE",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-07-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "UE", "Désinformation"]
+  },
+  {
+    domain: "greenarmenia.org",
+    matchType: "exact",
+    reason: "Site usurpant l'identité du Parti Vert arménien, utilisé pour diffuser de fausses accusations contre Orano et cibler les relations France-Arménie",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-06-27",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Arménie", "France", "Désinformation-Ciblée"]
+  },
+  {
+    domain: "darkquasar.tech",
+    matchType: "exact",
+    reason: "Site lié aux projets personnels de John Mark Dougan, hébergeant une page de connexion pour 'SKRYTY'",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-01",
+    riskLevel: "medium",
+    tags: ["CopyCop", "Russie", "Infrastructure", "Dougan"]
+  },
+  {
+    domain: "skryty.com",
+    matchType: "exact",
+    reason: "Site lié aux projets personnels de John Mark Dougan, hébergeant une page de connexion pour 'SKRYTY'",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-01",
+    riskLevel: "medium",
+    tags: ["CopyCop", "Russie", "Infrastructure", "Dougan"]
+  },
+  {
+    domain: "skryty.ru",
+    matchType: "exact",
+    reason: "Site lié aux projets personnels de John Mark Dougan, hébergeant une page de connexion pour 'SKRYTY', hébergé sur infrastructure russe",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-01",
+    riskLevel: "medium",
+    tags: ["CopyCop", "Russie", "Infrastructure", "Dougan"]
+  },
+  {
+    domain: "darkpulsar.ai",
+    matchType: "exact",
+    reason: "Site lié aux projets de Dougan, a hébergé une page de connexion avec le slogan 'Shining information to websites worldwide, like a pulsar beacon'",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-01",
+    riskLevel: "medium",
+    tags: ["CopyCop", "Russie", "Infrastructure", "Dougan"]
+  },
+  {
+    domain: "video.darkpulsar.ai",
+    matchType: "exact",
+    reason: "Plateforme PeerTube auto-hébergée liée aux projets de Dougan",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-01",
+    riskLevel: "medium",
+    tags: ["CopyCop", "Russie", "Infrastructure", "Dougan"]
+  },
+  {
+    domain: "chat.darkpulsar.ai",
+    matchType: "exact",
+    reason: "Page de connexion Open WebUI pour interaction avec des LLMs auto-hébergés, infrastructure LLM de CopyCop",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-03-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Infrastructure", "LLM", "Dougan"]
+  },
+  {
+    domain: "reuters.uk.net",
+    matchType: "exact",
+    reason: "Site potentiellement lié à CopyCop usurpant l'identité de Reuters",
+    source: "Recorded Future - Insikt Group",
+    reportUrl: "https://assets.recordedfuture.com/insikt-report-pdfs/2025/cta-ru-2025-0917.pdf",
+    identifiedDate: "2025-01-01",
+    riskLevel: "high",
+    tags: ["CopyCop", "Russie", "Usurpation-Identité", "Média"]
+  }
+];
+
+// Fonction utilitaire pour filtrer par tag
+function filterByTag(tag) {
+  return copycopDomains.filter(domain => domain.tags.includes(tag));
+}
+
+// Fonction utilitaire pour filtrer par niveau de risque
+function filterByRiskLevel(riskLevel) {
+  return copycopDomains.filter(domain => domain.riskLevel === riskLevel);
+}
+
+// Fonction utilitaire pour obtenir tous les tags uniques
+function getAllTags() {
+  const allTags = new Set();
+  copycopDomains.forEach(domain => {
+    domain.tags.forEach(tag => allTags.add(tag));
+  });
+  return Array.from(allTags).sort();
+}
+
+// Fonction utilitaire pour obtenir les domaines par date
+function getDomainsByDateRange(startDate, endDate) {
+  return copycopDomains.filter(d => {
+    const domainDate = new Date(d.identifiedDate);
+    return domainDate >= new Date(startDate) && domainDate <= new Date(endDate);
+  });
+}
+
+// Fonction utilitaire pour obtenir les statistiques
+function getStats() {
+  return {
+    total: copycopDomains.length,
+    highRisk: copycopDomains.filter(d => d.riskLevel === "high").length,
+    mediumRisk: copycopDomains.filter(d => d.riskLevel === "medium").length,
+    lowRisk: copycopDomains.filter(d => d.riskLevel === "low").length,
+    byCategory: {
+      "Sites-US": copycopDomains.filter(d => d.tags.includes("Sites-US")).length,
+      "Sites-France": copycopDomains.filter(d => d.tags.includes("Sites-France")).length,
+      "Sites-Canada": copycopDomains.filter(d => d.tags.includes("Sites-Canada")).length,
+      "Truefact": copycopDomains.filter(d => d.tags.includes("Truefact")).length,
+      "Infrastructure": copycopDomains.filter(d => d.tags.includes("Infrastructure")).length
+    },
+    byCountry: {
+      "USA": copycopDomains.filter(d => d.tags.includes("USA")).length,
+      "France": copycopDomains.filter(d => d.tags.includes("France")).length,
+      "Canada": copycopDomains.filter(d => d.tags.includes("Canada")).length,
+      "Arménie": copycopDomains.filter(d => d.tags.includes("Arménie")).length,
+      "Moldova": copycopDomains.filter(d => d.tags.includes("Moldova")).length,
+      "Ukraine": copycopDomains.filter(d => d.tags.includes("Ukraine")).length,
+      "Allemagne": copycopDomains.filter(d => d.tags.includes("Allemagne")).length,
+      "Turquie": copycopDomains.filter(d => d.tags.includes("Turquie")).length,
+      "Afrique": copycopDomains.filter(d => d.tags.includes("Afrique")).length
+    },
+    byTheme: {
+      "Anti-Ukraine": copycopDomains.filter(d => d.tags.includes("Anti-Ukraine")).length,
+      "Élections": copycopDomains.filter(d => d.tags.includes("Élections")).length,
+      "Désinformation-Ciblée": copycopDomains.filter(d => d.tags.includes("Désinformation-Ciblée")).length,
+      "Usurpation-Identité": copycopDomains.filter(d => d.tags.includes("Usurpation-Identité")).length,
+      "LLM": copycopDomains.filter(d => d.tags.includes("LLM")).length
+    }
+  };
+}
+
+// Export pour utilisation dans d'autres scripts
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    copycopDomains,
+    filterByTag,
+    filterByRiskLevel,
+    getAllTags,
+    getDomainsByDateRange,
+    getStats
+  };
+}
+
+console.log(`Liste CopyCop chargée: ${copycopDomains.length} domaines identifiés`);
+console.log("Statistiques:", getStats());
+console.log("Tags disponibles:", getAllTags().join(", "));

--- a/plugin/plugin_chrome/releases/Plugin-dima/data/databases/PortalKombat.js
+++ b/plugin/plugin_chrome/releases/Plugin-dima/data/databases/PortalKombat.js
@@ -1,0 +1,2122 @@
+// DIMA - Base de données d'opération Portal Kombat
+// Basé sur le rapport VIGINUM de février 2024
+
+/**
+ * PORTAL KOMBAT
+ * =============
+ * 
+ * Réseau structuré et coordonné de propagande pro-russe identifié par VIGINUM
+ * 
+ * Description:
+ * Un réseau de 193 "portails d'information" numériques aux caractéristiques similaires,
+ * diffusant des contenus pro-russes à destination d'audiences internationales.
+ * 
+ * Architecture:
+ * - Écosystème "historique" (depuis 2013): Sites ciblant Russie et Ukraine
+ * - Écosystème "-news.ru" (depuis 2022): Sites ciblant audiences russophones d'Ukraine
+ * - Écosystème "pravda" (depuis 2023): Sites ciblant pays occidentaux
+ * 
+ * Source: Rapport VIGINUM - Février 2024
+ */
+
+const portalKombatDomains = [
+  // ===== ÉCOSYSTÈME "PRAVDA" - CIBLANT PAYS OCCIDENTAUX =====
+  {
+    domain: "pravda-fr.com",
+    matchType: "exact",
+    reason: "Site de l'opération Portal Kombat ciblant la France, diffusant de la propagande pro-Kremlin et des narratifs anti-Ukraine",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2023-06-24",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "France",
+      "Anti-Ukraine",
+      "Pro-Kremlin",
+      "Propagande",
+      "LLM",
+      "Automatisation-Massive"
+    ]
+  },
+  {
+    domain: "pravda-de.com",
+    matchType: "exact",
+    reason: "Site de l'opération Portal Kombat ciblant l'Allemagne, l'Autriche et la Suisse avec propagande pro-russe",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2023-02-22",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Allemagne",
+      "Autriche",
+      "Suisse",
+      "Anti-Ukraine",
+      "Pro-Kremlin",
+      "Automatisation-Massive"
+    ]
+  },
+  {
+    domain: "pravda-pl.com",
+    matchType: "exact",
+    reason: "Site de l'opération Portal Kombat ciblant la Pologne avec des narratifs pro-Kremlin",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2023-06-24",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Pologne",
+      "Anti-Ukraine",
+      "Pro-Kremlin"
+    ]
+  },
+  {
+    domain: "pravda-es.com",
+    matchType: "exact",
+    reason: "Site de l'opération Portal Kombat ciblant l'Espagne avec propagande pro-russe",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2023-06-24",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Espagne",
+      "Anti-Ukraine",
+      "Pro-Kremlin"
+    ]
+  },
+  {
+    domain: "pravda-en.com",
+    matchType: "exact",
+    reason: "Site de l'opération Portal Kombat ciblant le Royaume-Uni et les États-Unis avec propagande pro-russe",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2023-06-24",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "UK",
+      "USA",
+      "Anti-Ukraine",
+      "Pro-Kremlin"
+    ]
+  },
+
+  // ===== ÉCOSYSTÈME "-NEWS.RU" - CIBLANT AUDIENCES RUSSOPHONES D'UKRAINE =====
+  {
+    domain: "kherson-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Kherson (Ukraine), amplifiant le ressentiment pro-russe contre les autorités ukrainiennes",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Kherson",
+      "Territoires-Occupés",
+      "Désinformation-Ciblée"
+    ]
+  },
+  {
+    domain: "mariupol-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Marioupol (Ukraine), zone stratégique occupée",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Marioupol",
+      "Territoires-Occupés"
+    ]
+  },
+  {
+    domain: "news-kiev.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Kiev avec propagande pro-russe et anti-gouvernement ukrainien",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Kiev",
+      "Anti-Gouvernement"
+    ]
+  },
+  {
+    domain: "donetsk-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Donetsk, région stratégique du conflit russo-ukrainien",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Donetsk",
+      "DNR",
+      "Territoires-Occupés"
+    ]
+  },
+  {
+    domain: "lugansk-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Louhansk, région stratégique du conflit",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Louhansk",
+      "LNR",
+      "Territoires-Occupés"
+    ]
+  },
+  {
+    domain: "lnr-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat pour la République populaire de Louhansk (LNR)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "LNR",
+      "Territoires-Occupés"
+    ]
+  },
+  {
+    domain: "dnr-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat pour la République populaire de Donetsk (DNR)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "DNR",
+      "Territoires-Occupés"
+    ]
+  },
+  {
+    domain: "news-kharkov.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Kharkiv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Kharkiv"
+    ]
+  },
+  {
+    domain: "news-odessa.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Odessa (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Odessa"
+    ]
+  },
+  {
+    domain: "dnepr-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Dnipro (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Dnipro"
+    ]
+  },
+  {
+    domain: "zp-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Zaporijjia (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Zaporijjia"
+    ]
+  },
+  {
+    domain: "cherkassy-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Cherkasy (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Cherkasy"
+    ]
+  },
+  {
+    domain: "poltava-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Poltava (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Poltava"
+    ]
+  },
+  {
+    domain: "vin-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Vinnytsia (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Vinnytsia"
+    ]
+  },
+  {
+    domain: "chernigov-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Tchernihiv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Tchernihiv"
+    ]
+  },
+  {
+    domain: "kirovograd-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Kropyvnytskyi (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Kropyvnytskyi"
+    ]
+  },
+  {
+    domain: "nikolaev-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Mykolaïv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Mykolaïv"
+    ]
+  },
+  {
+    domain: "sumy-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Sumy (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Sumy"
+    ]
+  },
+  {
+    domain: "zhitomir-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Jytomyr (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-03",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Jytomyr"
+    ]
+  },
+  {
+    domain: "berdyansk-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Berdiansk (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Berdiansk"
+    ]
+  },
+  {
+    domain: "melitopol-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Melitopol (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Melitopol"
+    ]
+  },
+  {
+    domain: "lvov-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Lviv (Ukraine), créé en décembre 2022 pour étendre la couverture vers l'ouest",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-12-17",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Lviv"
+    ]
+  },
+  {
+    domain: "ternopol-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Ternopil (Ukraine), extension vers l'ouest",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-12-17",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Ternopil"
+    ]
+  },
+  {
+    domain: "tiraspol-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant la Transnistrie (Moldavie), région sécessionniste pro-russe",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-26",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Moldavie",
+      "Transnistrie",
+      "Séparatisme"
+    ]
+  },
+  {
+    domain: "alchevsk-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Alchevsk dans la région de Louhansk",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Alchevsk",
+      "LNR"
+    ]
+  },
+  {
+    domain: "gorlovka-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Horlivka dans la région de Donetsk",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Horlivka",
+      "DNR"
+    ]
+  },
+  {
+    domain: "kramatorsk-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Kramatorsk (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Kramatorsk"
+    ]
+  },
+  {
+    domain: "slavyansk-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Sloviansk (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Sloviansk"
+    ]
+  },
+  {
+    domain: "news-makeevka.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Makiïvka dans la région de Donetsk",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Makiïvka",
+      "DNR"
+    ]
+  },
+  {
+    domain: "chernovcy-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Tchernivtsi (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-12-17",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Tchernivtsi"
+    ]
+  },
+  {
+    domain: "if-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Ivano-Frankivsk (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-12-17",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Ivano-Frankivsk"
+    ]
+  },
+  {
+    domain: "rovno-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Rivne (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-12-17",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Rivne"
+    ]
+  },
+  {
+    domain: "volyn-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant la région de Volhynie (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-12-17",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Volhynie"
+    ]
+  },
+  {
+    domain: "khmelnitskiy-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Khmelnytskyi (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-12-17",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Khmelnytskyi"
+    ]
+  },
+  {
+    domain: "uzhgorod-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Oujhorod (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-12-17",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Oujhorod",
+      "Transcarpatie"
+    ]
+  },
+  {
+    domain: "krivoy-rog-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Kryvyï Rih (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Kryvyï-Rih"
+    ]
+  },
+  {
+    domain: "dneprodzerzhinsknews.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Kamianske (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Kamianske"
+    ]
+  },
+  {
+    domain: "kremenchug-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Kremenchouk (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Kremenchouk"
+    ]
+  },
+  {
+    domain: "nikopol-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Nikopol (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Nikopol"
+    ]
+  },
+  {
+    domain: "pavlograd-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Pavlohrad (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Ukraine",
+      "Pavlohrad"
+    ]
+  },
+  {
+    domain: "bc-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat (identification à confirmer)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-04-18",
+    riskLevel: "medium",
+    tags: [
+      "Portal_Kombat",
+      "Russie"
+    ]
+  },
+
+  // ===== ÉCOSYSTÈME "HISTORIQUE" - SITES RUSSES (sélection des plus actifs) =====
+  {
+    domain: "piter-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Saint-Pétersbourg, diffuse contenus pro-FSB et pro-Kremlin",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-03-07",
+    riskLevel: "medium",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Saint-Pétersbourg",
+      "Infrastructure"
+    ]
+  },
+  {
+    domain: "moskva-news.com",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Moscou (inactif)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-03-09",
+    riskLevel: "low",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Moscou",
+      "Infrastructure",
+      "Inactif"
+    ]
+  },
+  {
+    domain: "msk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Moscou",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Moscou",
+      "Infrastructure"
+    ]
+  },
+  {
+    domain: "crimea-news.com",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la Crimée annexée",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-11-05",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Crimée",
+      "Annexion",
+      "Infrastructure"
+    ]
+  },
+  {
+    domain: "sevastopol-news.com",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Sébastopol (Crimée)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2015-06-04",
+    riskLevel: "high",
+    tags: [
+      "Portal_Kombat",
+      "Russie",
+      "Crimée",
+      "Sébastopol",
+      "Infrastructure"
+    ]
+  },
+
+  // ===== ÉCOSYSTÈME "HISTORIQUE" - SITES RUSSES (suite) =====
+  {
+    domain: "barnaul-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Barnaoul (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Barnaoul", "Infrastructure"]
+  },
+  {
+    domain: "chelyabinsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tcheliabinsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tcheliabinsk", "Infrastructure"]
+  },
+  {
+    domain: "irkutsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Irkoutsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Irkoutsk", "Infrastructure"]
+  },
+  {
+    domain: "izhevsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Ijevsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ijevsk", "Infrastructure"]
+  },
+  {
+    domain: "kazan-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kazan (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kazan", "Infrastructure"]
+  },
+  {
+    domain: "khabarovsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Khabarovsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Khabarovsk", "Infrastructure"]
+  },
+  {
+    domain: "krasnodar-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Krasnodar (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Krasnodar", "Infrastructure"]
+  },
+  {
+    domain: "krasnoyarsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Krasnoïarsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Krasnoïarsk", "Infrastructure"]
+  },
+  {
+    domain: "nn-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Nijni Novgorod (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Nijni-Novgorod", "Infrastructure"]
+  },
+  {
+    domain: "novosibirsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Novossibirsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Novossibirsk", "Infrastructure"]
+  },
+  {
+    domain: "omsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Omsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Omsk", "Infrastructure"]
+  },
+  {
+    domain: "perm-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Perm (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Perm", "Infrastructure"]
+  },
+  {
+    domain: "rostov-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Rostov-sur-le-Don (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Rostov-sur-le-Don", "Infrastructure"]
+  },
+  {
+    domain: "samara-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Samara (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Samara", "Infrastructure"]
+  },
+  {
+    domain: "saratov-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Saratov (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Saratov", "Infrastructure"]
+  },
+  {
+    domain: "sochi-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Sotchi (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Sotchi", "Infrastructure"]
+  },
+  {
+    domain: "tolyatti-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Togliatti (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Togliatti", "Infrastructure"]
+  },
+  {
+    domain: "tyumen-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tioumen (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tioumen", "Infrastructure"]
+  },
+  {
+    domain: "ufa-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Oufa (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Oufa", "Infrastructure"]
+  },
+  {
+    domain: "ulyanovsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Oulianovsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Oulianovsk", "Infrastructure"]
+  },
+  {
+    domain: "ural-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la région de l'Oural (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Oural", "Infrastructure"]
+  },
+  {
+    domain: "vladivostok-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Vladivostok (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Vladivostok", "Infrastructure"]
+  },
+  {
+    domain: "volgograd-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Volgograd (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Volgograd", "Infrastructure"]
+  },
+  {
+    domain: "voronezh-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Voronej (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Voronej", "Infrastructure"]
+  },
+  {
+    domain: "yaroslavl-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Iaroslavl (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-12-02",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Iaroslavl", "Infrastructure"]
+  },
+  {
+    domain: "astrakhan-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Astrakhan (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Astrakhan", "Infrastructure"]
+  },
+  {
+    domain: "arkhangelsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Arkhangelsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Arkhangelsk", "Infrastructure"]
+  },
+  {
+    domain: "belgorod-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Belgorod (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Belgorod", "Infrastructure"]
+  },
+  {
+    domain: "vladimir-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Vladimir (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Vladimir", "Infrastructure"]
+  },
+  {
+    domain: "vologda-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Vologda (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Vologda", "Infrastructure"]
+  },
+  {
+    domain: "dagestan-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant le Daghestan (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Daghestan", "Infrastructure"]
+  },
+  {
+    domain: "ivanovo-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Ivanovo (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ivanovo", "Infrastructure"]
+  },
+  {
+    domain: "kaliningrad-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kaliningrad (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kaliningrad", "Infrastructure"]
+  },
+  {
+    domain: "kirov-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kirov (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-04-09",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kirov", "Infrastructure"]
+  },
+  {
+    domain: "murmansk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Mourmansk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Mourmansk", "Infrastructure"]
+  },
+  {
+    domain: "kemerovo-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kemerovo (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kemerovo", "Infrastructure"]
+  },
+  {
+    domain: "penza-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Penza (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Penza", "Infrastructure"]
+  },
+  {
+    domain: "orenburg-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Orenbourg (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Orenbourg", "Infrastructure"]
+  },
+  {
+    domain: "orel-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Orel (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Orel", "Infrastructure"]
+  },
+  {
+    domain: "stavropol-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Stavropol (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Stavropol", "Infrastructure"]
+  },
+  {
+    domain: "smolensk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Smolensk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Smolensk", "Infrastructure"]
+  },
+  {
+    domain: "tomsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tomsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tomsk", "Infrastructure"]
+  },
+  {
+    domain: "tver-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tver (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tver", "Infrastructure"]
+  },
+  {
+    domain: "ryazan-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Riazan (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Riazan", "Infrastructure"]
+  },
+  {
+    domain: "tula-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Toula (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Toula", "Infrastructure"]
+  },
+  {
+    domain: "chita-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tchita (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tchita", "Infrastructure"]
+  },
+  {
+    domain: "kursk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Koursk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Koursk", "Infrastructure"]
+  },
+  {
+    domain: "lipetsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Lipetsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Lipetsk", "Infrastructure"]
+  },
+  {
+    domain: "saransk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Saransk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Saransk", "Infrastructure"]
+  },
+  {
+    domain: "kostroma-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kostroma (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kostroma", "Infrastructure"]
+  },
+  {
+    domain: "yamal-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la région de Iamal (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Iamal", "Infrastructure"]
+  },
+  {
+    domain: "tambov-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tambov (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tambov", "Infrastructure"]
+  },
+  {
+    domain: "kaluga-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kalouga (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kalouga", "Infrastructure"]
+  },
+  {
+    domain: "sakhalin-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Sakhaline (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Sakhaline", "Infrastructure"]
+  },
+  {
+    domain: "cheb-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tcheboksary (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tcheboksary", "Infrastructure"]
+  },
+  {
+    domain: "ugra-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Khantys-Mansiïsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Khantys-Mansiïsk", "Infrastructure"]
+  },
+  {
+    domain: "yakutsk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Iakoutsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Iakoutsk", "Infrastructure"]
+  },
+  {
+    domain: "kamchatka-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant le Kamtchatka (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kamtchatka", "Infrastructure"]
+  },
+  {
+    domain: "karelia-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la Carélie (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Carélie", "Infrastructure"]
+  },
+  {
+    domain: "komi-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la République des Komis (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Komis", "Infrastructure"]
+  },
+  {
+    domain: "udmurt-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant l'Oudmourtie (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Oudmourtie", "Infrastructure"]
+  },
+  {
+    domain: "kalmykia-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la Kalmoukie (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kalmoukie", "Infrastructure"]
+  },
+  {
+    domain: "tuva-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la Touva (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Touva", "Infrastructure"]
+  },
+  {
+    domain: "baikal-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la région du Baïkal (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-29",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Baïkal", "Infrastructure"]
+  },
+  {
+    domain: "pskov-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Pskov (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-11-30",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Pskov", "Infrastructure"]
+  },
+  {
+    domain: "altay-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant l'Altaï (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Altaï", "Infrastructure"]
+  },
+  {
+    domain: "ingushetiya-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant l'Ingouchie (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ingouchie", "Infrastructure"]
+  },
+  {
+    domain: "adygheya-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant l'Adyguée (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Adyguée", "Infrastructure"]
+  },
+  {
+    domain: "nalchik-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Naltchik (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Naltchik", "Infrastructure"]
+  },
+  {
+    domain: "mariel-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la République des Maris (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Maris", "Infrastructure"]
+  },
+  {
+    domain: "cherkessk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tcherkessk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tcherkessk", "Infrastructure"]
+  },
+  {
+    domain: "vladikavkaz-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Vladikavkaz (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Vladikavkaz", "Infrastructure"]
+  },
+  {
+    domain: "abakan-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Abakan (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Abakan", "Infrastructure"]
+  },
+  {
+    domain: "grozny-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Grozny (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Grozny", "Tchétchénie", "Infrastructure"]
+  },
+  {
+    domain: "amur-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la région de l'Amour (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Amour", "Infrastructure"]
+  },
+  {
+    domain: "bryansk-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Briansk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Briansk", "Infrastructure"]
+  },
+  {
+    domain: "kurgan-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kourgan (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Kourgan", "Infrastructure"]
+  },
+  {
+    domain: "birobidzhan-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Birobidjan (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Birobidjan", "Infrastructure"]
+  },
+  {
+    domain: "nao-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant le district autonome de Nénétsie (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Nénétsie", "Infrastructure"]
+  },
+  {
+    domain: "chukotka-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant la Tchoukotka (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Tchoukotka", "Infrastructure"]
+  },
+  {
+    domain: "novgorod-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Novgorod (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2018-12-26",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Novgorod", "Infrastructure"]
+  },
+  {
+    domain: "magadan-news.net",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Magadan (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2019-01-10",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Magadan", "Infrastructure"]
+  },
+  {
+    domain: "norilsk-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Norilsk (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-11-18",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Norilsk"]
+  },
+  {
+    domain: "nabchelny-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Naberejnye Tchelny (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-11-22",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Naberejnye-Tchelny"]
+  },
+  {
+    domain: "nk-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat (site russe, identification précise à confirmer)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-11-22",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie"]
+  },
+  {
+    domain: "tagil-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Nijni Taguil (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-11-22",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Nijni-Taguil"]
+  },
+  {
+    domain: "news-surgut.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Sourgout (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2022-11-22",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Sourgout"]
+  },
+  {
+    domain: "news-balashiha.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Balachikha (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2023-07-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Balachikha"]
+  },
+  {
+    domain: "volzhskiy-news.ru",
+    matchType: "exact",
+    reason: "Portail Portal Kombat ciblant Voljski (Russie)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2023-07-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Voljski"]
+  },
+
+  // ===== ÉCOSYSTÈME "HISTORIQUE" - SITES UKRAINIENS (.ua) =====
+  {
+    domain: "lenta.kharkiv.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kharkiv (Ukraine) - extension .ua",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-03-07",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Kharkiv", "Infrastructure"]
+  },
+  {
+    domain: "uanews.kharkiv.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kharkiv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-03-18",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Kharkiv", "Infrastructure"]
+  },
+  {
+    domain: "topnews.kiev.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kiev (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-03-24",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Kiev", "Infrastructure"]
+  },
+  {
+    domain: "topnews.odessa.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Odessa (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-03-30",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Odessa", "Infrastructure"]
+  },
+  {
+    domain: "uanews.odessa.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Odessa (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-03-30",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Odessa", "Infrastructure"]
+  },
+  {
+    domain: "dneprnews.com.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Dnipro (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-04-01",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Dnipro", "Infrastructure"]
+  },
+  {
+    domain: "uanews.dp.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Dnipro (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-04-01",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Dnipro", "Infrastructure"]
+  },
+  {
+    domain: "topnews.zp.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Zaporijjia (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-04-01",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Zaporijjia", "Infrastructure"]
+  },
+  {
+    domain: "uanews.zp.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Zaporijjia (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-04-01",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Zaporijjia", "Infrastructure"]
+  },
+  {
+    domain: "lenta.te.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Ternopil (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-04-08",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Ternopil", "Infrastructure"]
+  },
+  {
+    domain: "lenta.lviv.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Lviv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-04-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Lviv", "Infrastructure"]
+  },
+  {
+    domain: "uanews.donetsk.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Donetsk (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Donetsk", "Infrastructure"]
+  },
+  {
+    domain: "uanews.lviv.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Lviv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Lviv", "Infrastructure"]
+  },
+  {
+    domain: "topnews.volyn.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Volhynie (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Volhynie", "Infrastructure"]
+  },
+  {
+    domain: "topnews.cv.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tchernivtsi (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Tchernivtsi", "Infrastructure"]
+  },
+  {
+    domain: "uanews.te.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Ternopil (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Ternopil", "Infrastructure"]
+  },
+  {
+    domain: "topnews.zt.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Jytomyr (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Jytomyr", "Infrastructure"]
+  },
+  {
+    domain: "nikolaevnews.com.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Mykolaïv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Mykolaïv", "Infrastructure"]
+  },
+  {
+    domain: "topnews.pl.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Poltava (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Poltava", "Infrastructure"]
+  },
+  {
+    domain: "topnews.rv.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Rivne (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Rivne", "Infrastructure"]
+  },
+  {
+    domain: "topnews.cn.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tchernihiv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-11",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Tchernihiv", "Infrastructure"]
+  },
+  {
+    domain: "topnews.ck.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Tcherkasy (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-12",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Tcherkasy", "Infrastructure"]
+  },
+  {
+    domain: "topnews.kr.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kropyvnytskyi (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-12",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Kropyvnytskyi", "Infrastructure"]
+  },
+  {
+    domain: "topnews.vn.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Vinnytsia (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2013-05-14",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Vinnytsia", "Infrastructure"]
+  },
+  {
+    domain: "novyny.kr.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kropyvnytskyi (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2019-01-19",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Kropyvnytskyi", "Infrastructure"]
+  },
+  {
+    domain: "novyny.zt.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Jytomyr (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2019-01-19",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Jytomyr", "Infrastructure"]
+  },
+  {
+    domain: "gazeta.kharkiv.ua",
+    matchType: "exact",
+    reason: "Portail Portal Kombat historique ciblant Kharkiv (Ukraine)",
+    source: "VIGINUM (SGDSN)",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf",
+    identifiedDate: "2019-01-19",
+    riskLevel: "medium",
+    tags: ["Portal_Kombat", "Russie", "Ukraine", "Kharkiv", "Infrastructure"]
+  }
+
+];
+
+// Note: Cette liste contient maintenant 193 domaines identifiés par VIGINUM
+// dans le rapport de février 2024, répartis en trois écosystèmes distincts.
+
+// =============================================================================
+// FONCTIONS UTILITAIRES
+// =============================================================================
+
+// Filtrer par tag
+function filterPortalKombatByTag(tag) {
+  return portalKombatDomains.filter(d => d.tags.includes(tag));
+}
+
+// Filtrer par niveau de risque
+function filterPortalKombatByRiskLevel(level) {
+  return portalKombatDomains.filter(d => d.riskLevel === level);
+}
+
+// Filtrer par écosystème
+function filterPortalKombatByEcosystem(ecosystem) {
+  const ecosystemPatterns = {
+    "pravda": d => d.domain.startsWith("pravda-"),
+    "news.ru": d => d.domain.endsWith("-news.ru") || d.domain.endsWith("news.ru"),
+    "historique": d => !d.domain.startsWith("pravda-") && !d.domain.endsWith("-news.ru") && !d.domain.endsWith("news.ru")
+  };
+  
+  const pattern = ecosystemPatterns[ecosystem];
+  return pattern ? portalKombatDomains.filter(pattern) : [];
+}
+
+// Filtrer par pays ciblé
+function filterPortalKombatByTargetCountry(country) {
+  return portalKombatDomains.filter(d => 
+    d.tags.some(tag => tag.toLowerCase().includes(country.toLowerCase()))
+  );
+}
+
+// Obtenir tous les tags uniques
+function getPortalKombatTags() {
+  const allTags = new Set();
+  portalKombatDomains.forEach(d => {
+    d.tags.forEach(tag => allTags.add(tag));
+  });
+  return Array.from(allTags).sort();
+}
+
+// Obtenir les statistiques
+function getPortalKombatStats() {
+  const stats = {
+    total: portalKombatDomains.length,
+    highRisk: portalKombatDomains.filter(d => d.riskLevel === "high").length,
+    mediumRisk: portalKombatDomains.filter(d => d.riskLevel === "medium").length,
+    lowRisk: portalKombatDomains.filter(d => d.riskLevel === "low").length,
+    byEcosystem: {
+      pravda: filterPortalKombatByEcosystem("pravda").length,
+      newsRu: filterPortalKombatByEcosystem("news.ru").length,
+      historique: filterPortalKombatByEcosystem("historique").length
+    },
+    tags: getPortalKombatTags()
+  };
+  
+  return stats;
+}
+
+// =============================================================================
+// EXPORTS ET DISPONIBILITÉ GLOBALE
+// =============================================================================
+
+// Export pour Node.js / modules
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    portalKombatDomains,
+    filterPortalKombatByTag,
+    filterPortalKombatByRiskLevel,
+    filterPortalKombatByEcosystem,
+    filterPortalKombatByTargetCountry,
+    getPortalKombatTags,
+    getPortalKombatStats
+  };
+}
+
+// Disponibilité globale pour le navigateur
+if (typeof window !== 'undefined') {
+  window.portalKombatDomains = portalKombatDomains;
+  window.portalKombatUtils = {
+    filterByTag: filterPortalKombatByTag,
+    filterByRiskLevel: filterPortalKombatByRiskLevel,
+    filterByEcosystem: filterPortalKombatByEcosystem,
+    filterByTargetCountry: filterPortalKombatByTargetCountry,
+    getTags: getPortalKombatTags,
+    getStats: getPortalKombatStats
+  };
+}
+
+// Log de chargement
+console.log(`Liste Portal Kombat chargée: ${portalKombatDomains.length} domaines identifiés`);
+if (portalKombatDomains.length > 0) {
+  const stats = getPortalKombatStats();
+  console.log("Statistiques Portal Kombat:", stats);
+  console.log(`  - Écosystème "pravda": ${stats.byEcosystem.pravda} sites`);
+  console.log(`  - Écosystème "-news.ru": ${stats.byEcosystem.newsRu} sites`);
+  console.log(`  - Écosystème "historique": ${stats.byEcosystem.historique} sites`);
+}
+
+// =============================================================================
+// INFORMATIONS TECHNIQUES ADDITIONNELLES
+// =============================================================================
+
+/**
+ * CARACTÉRISTIQUES TECHNIQUES DU RÉSEAU (source: rapport VIGINUM)
+ * 
+ * Infrastructure:
+ * - Système autonome: AS49352 (Reg.ru)
+ * - Adresses IP partagées (ex: 178.21.15.*)
+ * - Favicon identique: MurmurHash3 -200225920
+ * - E-Tag caractéristique: 640ba6a8-d9c
+ * 
+ * Modes opératoires:
+ * - Automatisation massive des publications (jusqu'à 1734 articles/jour)
+ * - Optimisation SEO pour mots-clés de "longue traîne"
+ * - Traduction automatique (erreurs typiques RU → FR/EN/DE/ES/PL)
+ * - Publication 24/7 avec baisse entre 1h-6h
+ * - Moyenne de 9 publications/heure sur Telegram
+ * 
+ * Sources principales:
+ * - Chaînes Telegram pro-russes
+ * - Agences de presse russes (TASS, RIA Novosti, Izvestia)
+ * - Sites officiels russes (crimea.gov.ru, etc.)
+ * 
+ * Narratifs diffusés:
+ * - Légitimation de "l'opération militaire spéciale"
+ * - Dénigrement de l'Ukraine et de ses dirigeants
+ * - Critique de "l'Occident collectif"
+ * - Promotion du FSB et services de sécurité russes
+ * - Polarisation du débat public numérique
+ */

--- a/plugin/plugin_chrome/releases/Plugin-dima/data/databases/RRN.js
+++ b/plugin/plugin_chrome/releases/Plugin-dima/data/databases/RRN.js
@@ -1,0 +1,1217 @@
+// Liste des domaines identifiés dans la campagne RRN de manipulation de l'information
+// Source: Rapport VIGINUM - 19 juin 2023
+// RRN: une campagne numérique de manipulation de l'information complexe et persistante
+
+const rrnCampaignDomains = [
+  // ===== DOMAINES PRINCIPAUX DE LA CAMPAGNE RRN =====
+  {
+    domain: "rrussianews.com",
+    matchType: "exact",
+    reason: "Site principal RRN (Reliable Russian News), créé le 10 mars 2022, média pro-russe diffusant de la désinformation sur l'Ukraine",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-03-10",
+    riskLevel: "high",
+    tags: ["RRN", "core-infrastructure", "France", "multi-langue", "désinformation-Ukraine"]
+  },
+  {
+    domain: "rrn.world",
+    matchType: "exact",
+    reason: "Nouveau domaine principal de RRN créé le 6 juin 2022 pour masquer les liens avec la Russie (anciennement Reliable Russian News, devenu Reliable Recent News)",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-06-06",
+    riskLevel: "high",
+    tags: ["RRN", "core-infrastructure", "France", "multi-langue", "désinformation-Ukraine"]
+  },
+  {
+    domain: "waronfakes.com",
+    matchType: "exact",
+    reason: "Fausse plateforme de fact-checking utilisée par la Russie pour nier les crimes de guerre et légitimer l'invasion de l'Ukraine. Lien technique avec rrussianews.com",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-03-01",
+    riskLevel: "high",
+    tags: ["RRN", "fact-checking-fake", "désinformation-Ukraine", "propagande-russe"]
+  },
+
+  // ===== SITES AFFILIÉS ET FAUX MÉDIAS =====
+  {
+    domain: "avisindependent.eu",
+    matchType: "exact",
+    reason: "Site 'La France indépendante' créé le 1er juin 2022, faux média d'analyse sur la guerre en Ukraine. Enregistré par NetBuzz/Mikhaïl TCHEKOMASOV",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-06-01",
+    riskLevel: "high",
+    tags: ["RRN", "France", "faux-média", "désinformation-Ukraine"]
+  },
+  {
+    domain: "newsroad.online",
+    matchType: "exact",
+    reason: "Infrastructure parallèle à RRN créée le 6 avril 2022, publie des articles en plusieurs langues et partage des caricatures pro-russes. Enregistré par Andreï CHOUBOTCHKINE",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-04-06",
+    riskLevel: "high",
+    tags: ["RRN", "multi-langue", "caricatures", "désinformation-Ukraine"]
+  },
+  {
+    domain: "memhouse.online",
+    matchType: "exact",
+    reason: "Site créé le 15 avril 2022, banque de caricatures anti-occidentales et pro-russes utilisées dans la campagne RRN. Enregistré par Andreï CHOUBOTCHKINE",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-04-15",
+    riskLevel: "high",
+    tags: ["RRN", "caricatures", "propagande-visuelle"]
+  },
+  {
+    domain: "truemaps.info",
+    matchType: "exact",
+    reason: "Site créé le 30 juin 2022, carte interactive accusant les pays fournisseurs d'armes à l'Ukraine de tuer des enfants dans le Donbass. Code source en cyrillique",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-06-30",
+    riskLevel: "high",
+    tags: ["RRN", "propagande-émotionnelle", "désinformation-Ukraine"]
+  },
+  {
+    domain: "tribunalukraine.info",
+    matchType: "exact",
+    reason: "Site créé le 5 octobre 2022, publie des articles sur de supposés crimes de guerre ukrainiens. Prétend être administré par des allemands",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-10-05",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "désinformation-Ukraine", "crimes-guerre-fake"]
+  },
+  {
+    domain: "ukraine-inc.info",
+    matchType: "exact",
+    reason: "Site créé le 11 mars 2023, héberge la série de dessins animés 'Ukraine Cocaïne' anti-Zelensky. Serveur hébergé en Russie, relayé massivement par les canaux Telegram russes",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-03-11",
+    riskLevel: "high",
+    tags: ["RRN", "dessin-animé", "anti-Zelensky", "désinformation-Ukraine"]
+  },
+
+  // ===== FAUX SITES D'ACTUALITÉ FRANCOPHONES =====
+  {
+    domain: "lavirgule.news",
+    matchType: "exact",
+    reason: "Faux média francophone 'La Virgule' créé le 24 février 2023, critiques du gouvernement français et propagande pro-russe. Primo-diffuseur d'Ukraine Cocaïne",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02-24",
+    riskLevel: "high",
+    tags: ["RRN", "France", "faux-média", "désinformation-Ukraine"]
+  },
+  {
+    domain: "allons-y.social",
+    matchType: "exact",
+    reason: "Faux média francophone créé le 24 février 2023, articles sur la politique française avec éléments de langage russes. Erreurs de traduction cyrillique visibles",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02-24",
+    riskLevel: "high",
+    tags: ["RRN", "France", "faux-média", "désinformation-Ukraine"]
+  },
+  {
+    domain: "candidat.news",
+    matchType: "exact",
+    reason: "Faux média francophone créé le 24 février 2023, messages d'erreur en russe révélant l'origine russe du site",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02-24",
+    riskLevel: "high",
+    tags: ["RRN", "France", "faux-média"]
+  },
+  {
+    domain: "notrepays.today",
+    matchType: "exact",
+    reason: "Faux média francophone créé le 24 février 2023, hébergé sur le même serveur que lavirgule.news",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02-24",
+    riskLevel: "high",
+    tags: ["RRN", "France", "faux-média"]
+  },
+  {
+    domain: "franceeteu.today",
+    matchType: "exact",
+    reason: "Faux média francophone créé le 24 février 2023, hébergé sur le même serveur que lavirgule.news",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02-24",
+    riskLevel: "high",
+    tags: ["RRN", "France", "faux-média"]
+  },
+  {
+    domain: "librelepresse.fr",
+    matchType: "exact",
+    reason: "Faux site d'actualité francophone, publie des articles traduits du média RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "France", "faux-média"]
+  },
+
+  // ===== AUTRES FAUX SITES D'ACTUALITÉ (NON-FRANÇAIS) =====
+  {
+    domain: "weltereignisse365.de",
+    matchType: "exact",
+    reason: "Faux site d'actualité allemand, publie du contenu RRN traduit",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "faux-média"]
+  },
+  {
+    domain: "viedo-klis.lv",
+    matchType: "exact",
+    reason: "Faux site d'actualité letton, publie du contenu RRN traduit",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "Lettonie", "faux-média"]
+  },
+  {
+    domain: "libera-stampa.it",
+    matchType: "exact",
+    reason: "Faux site d'actualité italien, publie du contenu RRN traduit",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "Italie", "faux-média"]
+  },
+
+  // ===== TYPOSQUATTING - MÉDIAS FRANÇAIS =====
+  {
+    domain: "leparisien.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du Parisien, au moins 49 faux articles identifiés diffusant de la désinformation pro-russe",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "France", "typosquatting", "Le-Parisien"]
+  },
+  {
+    domain: "20minuts.com",
+    matchType: "exact",
+    reason: "Typosquatting de 20 Minutes (faute d'orthographe délibérée), 7 faux articles identifiés",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "high",
+    tags: ["RRN", "France", "typosquatting", "20-Minutes"]
+  },
+  {
+    domain: "lemonde.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du Monde, au moins 1 faux article identifié",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "France", "typosquatting", "Le-Monde"]
+  },
+  {
+    domain: "lefigaro.me",
+    matchType: "exact",
+    reason: "Typosquatting du Figaro à partir du 8 juin 2023, au moins 1 faux article identifié",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-06-08",
+    riskLevel: "high",
+    tags: ["RRN", "France", "typosquatting", "Le-Figaro"]
+  },
+
+  // ===== TYPOSQUATTING - SITES GOUVERNEMENTAUX =====
+  {
+    domain: "diplomatie.gouv.fm",
+    matchType: "exact",
+    reason: "Typosquatting du site du ministère de l'Europe et des Affaires étrangères français, faux communiqué sur une taxe de sécurité pour financer l'Ukraine",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-05-29",
+    riskLevel: "high",
+    tags: ["RRN", "France", "typosquatting", "gouvernement", "MEAE"]
+  },
+  {
+    domain: "bmi.bund.pe",
+    matchType: "exact",
+    reason: "Typosquatting du site du ministère de l'intérieur allemand, faux communiqué sur l'obligation d'accueillir des réfugiés ukrainiens",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-05-29",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "typosquatting", "gouvernement"]
+  },
+
+  // ===== TYPOSQUATTING - MÉDIAS ALLEMANDS =====
+  {
+    domain: "bild.work",
+    matchType: "exact",
+    reason: "Typosquatting du média allemand Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "spiegel.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du média allemand Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "sueddeutsche.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du média allemand Süddeutsche Zeitung",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "welt.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du média allemand Die Welt",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "typosquatting", "Die-Welt"]
+  },
+  {
+    domain: "faz.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du média allemand FAZ",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "typosquatting", "FAZ"]
+  },
+  {
+    domain: "tagesspiegel.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du média allemand Tagesspiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "high",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+
+  // ===== TYPOSQUATTING - AUTRES MÉDIAS INTERNATIONAUX =====
+  {
+    domain: "dailymail.top",
+    matchType: "exact",
+    reason: "Typosquatting du Daily Mail britannique",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Royaume-Uni", "typosquatting", "Daily-Mail"]
+  },
+  {
+    domain: "repubblica.life",
+    matchType: "exact",
+    reason: "Typosquatting du média italien La Repubblica",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Italie", "typosquatting", "La-Repubblica"]
+  },
+  {
+    domain: "ansa.ltd",
+    matchType: "exact",
+    reason: "Typosquatting de l'agence italienne ANSA",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Italie", "typosquatting", "ANSA"]
+  },
+  {
+    domain: "delfi.life",
+    matchType: "exact",
+    reason: "Typosquatting du média balte Delfi",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Pays-Baltes", "typosquatting", "Delfi"]
+  },
+  {
+    domain: "rbk.media",
+    matchType: "exact",
+    reason: "Typosquatting du média russe RBK",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Russie", "typosquatting", "RBK"]
+  },
+  {
+    domain: "obozrevatel.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du média ukrainien Obozrevatel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "Ukraine", "typosquatting"]
+  },
+  {
+    domain: "washingtonpost.ltd",
+    matchType: "exact",
+    reason: "Typosquatting du Washington Post",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "États-Unis", "typosquatting", "Washington-Post"]
+  },
+  {
+    domain: "albayan.me",
+    matchType: "exact",
+    reason: "Typosquatting du média émirati Al Bayan",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "Émirats-Arabes-Unis", "typosquatting"]
+  },
+  {
+    domain: "gulfnews.ltd",
+    matchType: "exact",
+    reason: "Typosquatting de Gulf News",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "Émirats-Arabes-Unis", "typosquatting"]
+  },
+  {
+    domain: "jewishjournal.info",
+    matchType: "exact",
+    reason: "Typosquatting du Jewish Journal",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "Israël", "typosquatting"]
+  },
+  {
+    domain: "mako.news",
+    matchType: "exact",
+    reason: "Typosquatting du média israélien Mako",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "Israël", "typosquatting"]
+  },
+  {
+    domain: "theliberal.net",
+    matchType: "exact",
+    reason: "Typosquatting d'un média libéral",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "typosquatting"]
+  },
+
+  // ===== DOMAINES DE REDIRECTION (INFRASTRUCTURE TECHNIQUE) =====
+  {
+    domain: "urlbox.online",
+    matchType: "exact",
+    reason: "Raccourcisseur d'URL utilisé pour masquer les destinations vers les sites typosquattés. Enregistré par Andreï CHOUBOTCHKINE",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-09",
+    riskLevel: "high",
+    tags: ["RRN", "redirecteur", "infrastructure-technique"]
+  },
+  {
+    domain: "marvelgoodies.com",
+    matchType: "exact",
+    reason: "Domaine pivot permanent utilisé pour les redirections vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "redirecteur", "infrastructure-technique"]
+  },
+  {
+    domain: "bighorn-advisors.com",
+    matchType: "exact",
+    reason: "Domaine pivot permanent utilisé pour les redirections vers les sites RRN, avec geofencing",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "redirecteur", "infrastructure-technique", "geofencing"]
+  },
+  {
+    domain: "gitver.com",
+    matchType: "exact",
+    reason: "Domaine pivot permanent utilisé pour les redirections vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "redirecteur", "infrastructure-technique"]
+  },
+  {
+    domain: "raremotion.com",
+    matchType: "exact",
+    reason: "Domaine pivot permanent utilisé pour les redirections vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "redirecteur", "infrastructure-technique"]
+  },
+  {
+    domain: "gooddefr.com",
+    matchType: "exact",
+    reason: "Domaine pivot permanent utilisé pour les redirections vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "high",
+    tags: ["RRN", "redirecteur", "infrastructure-technique"]
+  },
+
+  // ===== DOMAINES JETABLES DE REDIRECTION (échantillon des 130+ identifiés) =====
+  {
+    domain: "michaelplaxico.com",
+    matchType: "exact",
+    reason: "Domaine jetable utilisé dans les publications sponsorisées Facebook pour redirection vers RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "redirecteur-jetable", "Facebook-ads"]
+  },
+  {
+    domain: "google-seo-top.com",
+    matchType: "exact",
+    reason: "Domaine jetable utilisé pour redirection vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "redirecteur-jetable"]
+  },
+  {
+    domain: "nexusfall.com",
+    matchType: "exact",
+    reason: "Domaine jetable utilisé pour redirection vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "redirecteur-jetable"]
+  },
+  {
+    domain: "swiftdawn.com",
+    matchType: "exact",
+    reason: "Domaine jetable utilisé pour redirection vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "redirecteur-jetable"]
+  },
+  {
+    domain: "topsnoep.com",
+    matchType: "exact",
+    reason: "Domaine jetable utilisé pour redirection vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "redirecteur-jetable"]
+  },
+  {
+    domain: "americanconservativegazette.com",
+    matchType: "exact",
+    reason: "Domaine jetable utilisé pour redirection vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "redirecteur-jetable", "États-Unis"]
+  },
+  {
+    domain: "americanliberalmedia.com",
+    matchType: "exact",
+    reason: "Domaine jetable utilisé pour redirection vers les sites RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2023-02",
+    riskLevel: "medium",
+    tags: ["RRN", "redirecteur-jetable", "États-Unis"]
+  },
+
+  // ===== AUTRES VARIANTES DE TYPOSQUATTING (échantillon des 353 domaines) =====
+  {
+    domain: "blld.live",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "bild.pics",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "bild.live",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "bild.asia",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "bild.vip",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "bild.eu.com",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "bild.llc",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "bild.expert",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "bild.ws",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Bild",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Bild"]
+  },
+  {
+    domain: "welt.tours",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Die Welt",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Die-Welt"]
+  },
+  {
+    domain: "welt.ws",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Die Welt",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Die-Welt"]
+  },
+  {
+    domain: "welt.media",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Die Welt",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Die-Welt"]
+  },
+  {
+    domain: "spiegel.today",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegel.fun",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegel.quest",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegel.ink",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegel.pro",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegel.co.com",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegel.agency",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegel.work",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegel.cab",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegelr.live",
+    matchType: "exact",
+    reason: "Variante avec faute d'orthographe de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegelr.today",
+    matchType: "exact",
+    reason: "Variante avec faute d'orthographe de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegelr.life",
+    matchType: "exact",
+    reason: "Variante avec faute d'orthographe de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegeli.life",
+    matchType: "exact",
+    reason: "Variante avec faute d'orthographe de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegeli.live",
+    matchType: "exact",
+    reason: "Variante avec faute d'orthographe de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "spiegeli.today",
+    matchType: "exact",
+    reason: "Variante avec faute d'orthographe de Der Spiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "Der-Spiegel"]
+  },
+  {
+    domain: "sueddeutsche.online",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Süddeutsche Zeitung",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "sueddeutsche.life",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Süddeutsche Zeitung",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "sueddeutsche.today",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Süddeutsche Zeitung",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "sueddeutsche.me",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Süddeutsche Zeitung",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "sueddeutsche.cc",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Süddeutsche Zeitung",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "sueddeutsche.co",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Süddeutsche Zeitung",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "t-online.life",
+    matchType: "exact",
+    reason: "Typosquatting de T-Online (média allemand)",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "tonline.cfd",
+    matchType: "exact",
+    reason: "Typosquatting de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "tonline.life",
+    matchType: "exact",
+    reason: "Typosquatting de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "tonline.today",
+    matchType: "exact",
+    reason: "Typosquatting de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "t-onlinl.life",
+    matchType: "exact",
+    reason: "Typosquatting avec faute d'orthographe de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "t-onlinl.live",
+    matchType: "exact",
+    reason: "Typosquatting avec faute d'orthographe de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "t-onlinl.today",
+    matchType: "exact",
+    reason: "Typosquatting avec faute d'orthographe de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "t-onlinr.life",
+    matchType: "exact",
+    reason: "Typosquatting avec faute d'orthographe de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "t-onlinr.live",
+    matchType: "exact",
+    reason: "Typosquatting avec faute d'orthographe de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "t-onlinr.today",
+    matchType: "exact",
+    reason: "Typosquatting avec faute d'orthographe de T-Online",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "faz.agency",
+    matchType: "exact",
+    reason: "Variante de typosquatting de FAZ",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "FAZ"]
+  },
+  {
+    domain: "faz.life",
+    matchType: "exact",
+    reason: "Variante de typosquatting de FAZ",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting", "FAZ"]
+  },
+  {
+    domain: "tagesspiegel.co",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Tagesspiegel",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "nd-aktuell.net",
+    matchType: "exact",
+    reason: "Typosquatting du média allemand Neues Deutschland",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "nd-aktuell.pro",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Neues Deutschland",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "nd-aktuell.co",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Neues Deutschland",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne", "typosquatting"]
+  },
+  {
+    domain: "dailymail.cam",
+    matchType: "exact",
+    reason: "Variante de typosquatting du Daily Mail",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Royaume-Uni", "typosquatting", "Daily-Mail"]
+  },
+  {
+    domain: "dailymail.cfd",
+    matchType: "exact",
+    reason: "Variante de typosquatting du Daily Mail",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Royaume-Uni", "typosquatting", "Daily-Mail"]
+  },
+  {
+    domain: "theguardian.co.com",
+    matchType: "exact",
+    reason: "Typosquatting du Guardian britannique",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Royaume-Uni", "typosquatting", "The-Guardian"]
+  },
+  {
+    domain: "delfi.today",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Delfi",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Pays-Baltes", "typosquatting", "Delfi"]
+  },
+  {
+    domain: "delfi.top",
+    matchType: "exact",
+    reason: "Variante de typosquatting de Delfi",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Pays-Baltes", "typosquatting", "Delfi"]
+  },
+  {
+    domain: "delfl.cc",
+    matchType: "exact",
+    reason: "Variante avec faute d'orthographe de Delfi",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Pays-Baltes", "typosquatting", "Delfi"]
+  },
+  {
+    domain: "lsm.li",
+    matchType: "exact",
+    reason: "Typosquatting d'un média balte",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Pays-Baltes", "typosquatting"]
+  },
+  {
+    domain: "rbk.kiev.ua",
+    matchType: "exact",
+    reason: "Typosquatting de RBK ciblant l'Ukraine",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Ukraine", "typosquatting", "RBK"]
+  },
+  {
+    domain: "rbk.today",
+    matchType: "exact",
+    reason: "Variante de typosquatting de RBK",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Russie", "typosquatting", "RBK"]
+  },
+  {
+    domain: "reuters.cfd",
+    matchType: "exact",
+    reason: "Typosquatting de Reuters",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "international", "typosquatting", "Reuters"]
+  },
+  {
+    domain: "obozrevatels.com",
+    matchType: "exact",
+    reason: "Variante de typosquatting d'Obozrevatel (Ukraine)",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Ukraine", "typosquatting"]
+  },
+  {
+    domain: "schlauespiel.de",
+    matchType: "exact",
+    reason: "Domaine lié à la campagne RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne"]
+  },
+  {
+    domain: "elfpress.info",
+    matchType: "exact",
+    reason: "Domaine lié à la campagne RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN"]
+  },
+  {
+    domain: "zestiftung.com",
+    matchType: "exact",
+    reason: "Domaine lié à la campagne RRN",
+    source: "VIGINUM",
+    reportUrl: "https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf",
+    identifiedDate: "2022-05",
+    riskLevel: "medium",
+    tags: ["RRN", "Allemagne"]
+  }
+];
+
+// Export pour utilisation dans d'autres modules
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = rrnCampaignDomains;
+}
+
+// Note: Le rapport VIGINUM identifie 353 domaines au total. 
+// Cette liste contient les domaines principaux et les plus significatifs.
+// Les 130+ domaines jetables de redirection supplémentaires sont disponibles 
+// dans l'Annexe 4 du rapport original.

--- a/plugin/plugin_chrome/releases/Plugin-dima/data/databases/Storm1516.js
+++ b/plugin/plugin_chrome/releases/Plugin-dima/data/databases/Storm1516.js
@@ -1,0 +1,6124 @@
+// DIMA - Base de données du mode opératoire STORM-1516
+// Mode opératoire informationnel russe coordonné
+// Source: VIGINUM (SGDSN) - Rapport technique Mai 2025
+
+/**
+ * MODE OPÉRATOIRE STORM-1516
+ * ===========================
+ * 
+ * Description: Mode opératoire informationnel (MOI) russe actif depuis août 2023, 
+ * responsable de dizaines d'opérations informationnelles ciblant des audiences occidentales.
+ * 
+ * Objectifs principaux:
+ * - Décrédibiliser le gouvernement ukrainien et Volodymyr ZELENSKY
+ * - Saper le soutien occidental à l'Ukraine
+ * - Cibler des processus électoraux (France, USA, Allemagne)
+ * - Propager narratifs conspirationnistes et anxiogènes
+ * - Décrédibiliser l'opposition russe en exil
+ * 
+ * Acteurs impliqués:
+ * - John Mark DOUGAN (réseau CopyCop/MAGAstan)
+ * - Youry KHOROCHENKY (GRU, unité 29155)
+ * - Centre d'expertise géopolitique (CEG) - Valéry KOROVINE
+ * - Projet Lakhta (Internet Research Agency)
+ * - Écosystème Aleksandr DOUGUINE et Evgueni PRIGOJINE
+ * 
+ * Caractéristiques techniques:
+ * - Deepfakes vidéo et audio
+ * - Montages photos et vidéos
+ * - Utilisation d'acteurs amateurs
+ * - Réseau CopyCop: 293+ noms de domaine
+ * - Blanchiment via médias africains et moyen-orientaux
+ * - Amplification coordonnée multilingue
+ * 
+ * Période d'activité: Août 2023 - aujourd'hui (actif)
+ * Classification: Ingérence numérique étrangère
+ * Attribution: Gouvernement de la Fédération de Russie
+ * 
+ * Dernière mise à jour: 25 mars 2025
+ */
+
+const storm1516Domains = [
+  
+  // ===== RÉSEAU COPYCOP (John Mark DOUGAN) =====
+  // Infrastructure principale de diffusion - 293 domaines identifiés
+  
+  {
+    domain: "1776.chat",
+    matchType: "exact",
+    reason: "Nom de domaine du réseau CopyCop administré par John Mark DOUGAN, ancien policier américain exilé en Russie depuis 2016",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Infrastructure",
+      "Faux-Sites-Information"
+    ]
+  },
+
+  {
+    domain: "aktuellde.de",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop ciblant l'audience allemande, alimenté par articles reformulés via IA générative",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne",
+      "IA-Générative"
+    ]
+  },
+
+  {
+    domain: "aktuellenews-berlin.de",
+    matchType: "exact",
+    reason: "Faux site d'information local allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne",
+      "Usurpation-Identité"
+    ]
+  },
+
+  {
+    domain: "aktuelles-aus-nurnberg.de",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant l'identité de média local de Nuremberg",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne",
+      "Usurpation-Identité"
+    ]
+  },
+
+  {
+    domain: "alles-klar-hamburg.de",
+    matchType: "exact",
+    reason: "Faux média local hambourgeois du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "alles-wichtig-news.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "allethemen24.de",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience germanophone",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "american-freedom.org",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience américaine conservatrice",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Élections-2024"
+    ]
+  },
+
+  {
+    domain: "an-berlin.de",
+    matchType: "exact",
+    reason: "Faux média berlinois du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "anderemeinung.de",
+    matchType: "exact",
+    reason: "Site CopyCop exploité pour cibler les élections fédérales allemandes de février 2025",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-11-19",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne",
+      "Élections-Allemagne-2025",
+      "Campagne-Électorale"
+    ]
+  },
+
+  {
+    domain: "atlantabeacon.org",
+    matchType: "exact",
+    reason: "Faux site d'information locale d'Atlanta, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "atlanta-observer.com",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant identité de média d'Atlanta",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "ausdemueberall.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique allemand, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "austincrier.com",
+    matchType: "exact",
+    reason: "Faux média local d'Austin, Texas, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "badvolf.com",
+    matchType: "exact",
+    reason: "Site personnel historique de John Mark DOUGAN, enregistré le 10 avril 2017. Point d'origine du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-04-10",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Infrastructure-Origine"
+    ]
+  },
+
+  {
+    domain: "badvolf.ru",
+    matchType: "exact",
+    reason: "Extension russe du site personnel de John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-04-10",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN"
+    ]
+  },
+
+  {
+    domain: "bbc-uk.news",
+    matchType: "exact",
+    reason: "Typosquatting de BBC par John Mark DOUGAN, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Typosquatting",
+      "Sites-UK",
+      "Usurpation-Identité"
+    ]
+  },
+
+  {
+    domain: "b-blatt.de",
+    matchType: "exact",
+    reason: "Faux journal allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "berlin-apropos.de",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant média berlinois",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "berlinertagespost.de",
+    matchType: "exact",
+    reason: "Faux quotidien berlinois, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "berliner-wochenzeitung.de",
+    matchType: "exact",
+    reason: "Site majeur du réseau CopyCop. Hébergé sur IP 63.250.43[.]138-139, liées à ensemble-24.fr (opération élections législatives françaises 2024)",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne",
+      "Infrastructure-Clé"
+    ]
+  },
+
+  {
+    domain: "bostontimes.org",
+    matchType: "exact",
+    reason: "Faux média de Boston, réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "botbook.us",
+    matchType: "exact",
+    reason: "Site promotionnel du livre de John Mark DOUGAN, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN"
+    ]
+  },
+
+  {
+    domain: "britishchronicle.com",
+    matchType: "exact",
+    reason: "Faux média britannique, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-UK"
+    ]
+  },
+
+  {
+    domain: "brlnr-stimme.de",
+    matchType: "exact",
+    reason: "Site CopyCop imitant média berlinois",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "capitolpulse.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience politique américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "carsondispatch.com",
+    matchType: "exact",
+    reason: "Faux média local américain, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "casinohotelvunipalace.com",
+    matchType: "exact",
+    reason: "Site CopyCop créé pour opération spécifique: fausse acquisition par ZELENSKY d'un casino à Chypre. Hébergé IP 63.250.43[.]144-145, cluster CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-05-31",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Opération-Spécifique",
+      "Anti-Ukraine",
+      "ZELENSKY"
+    ]
+  },
+
+  {
+    domain: "centernewscentral.com",
+    matchType: "exact",
+    reason: "Site d'information inauthentique américain, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "centerpointbeacon.com",
+    matchType: "exact",
+    reason: "Faux média américain du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "centralrecord.org",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant média américain",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "chicagochron.com",
+    matchType: "exact",
+    reason: "Faux média de Chicago enregistré en janvier 2024 par John Mark DOUGAN, se faisant passer pour média américain",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "chicagocrier.com",
+    matchType: "exact",
+    reason: "Site CopyCop imitant journal de Chicago",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "cito-novit.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "civiccentury.org",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience civique américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "civiccommentary.org",
+    matchType: "exact",
+    reason: "Faux site de commentaire politique, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "civiccorner.org",
+    matchType: "exact",
+    reason: "Site CopyCop imitant plateforme citoyenne",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "civiccreed.com",
+    matchType: "exact",
+    reason: "Faux site civique américain, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "civiccurrent.com",
+    matchType: "exact",
+    reason: "Site CopyCop se faisant passer pour média d'actualité civique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "civiccurve.com",
+    matchType: "exact",
+    reason: "Faux média civique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "clearstory.news",
+    matchType: "exact",
+    reason: "Un des premiers faux sites d'actualité CopyCop. A amplifié les premières opérations Storm-1516 (août 2023 - mars 2024)",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2023-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Infrastructure-Historique",
+      "IA-Générative"
+    ]
+  },
+
+  {
+    domain: "conservativecamp.org",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience conservatrice américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "conservativecatch.org",
+    matchType: "exact",
+    reason: "Faux média conservateur du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "conservativechannel.org",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme chaîne d'information conservatrice",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "conservativecircuit.com",
+    matchType: "exact",
+    reason: "Faux réseau conservateur, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "conservativecompass.org",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant électeurs conservateurs américains",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "conservativecontext.com",
+    matchType: "exact",
+    reason: "Faux média d'analyse conservatrice du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "conservativecorridor.com",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme hub conservateur",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "conservativecourier.org",
+    matchType: "exact",
+    reason: "Faux journal conservateur, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "dailyregisternews.com",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant média américain",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "das-denkt-hamburg.de",
+    matchType: "exact",
+    reason: "Faux site d'opinion hambourgeois du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "dasneueste-online.de",
+    matchType: "exact",
+    reason: "Site d'actualité inauthentique allemand, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "daybreakdigest.org",
+    matchType: "exact",
+    reason: "Faux digest d'information américain, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "dc-free-press.org",
+    matchType: "exact",
+    reason: "Site CopyCop imitant presse indépendante de Washington DC",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "dcweekly.org",
+    matchType: "exact",
+    reason: "Un des premiers sites d'actualité CopyCop. Infrastructure historique hébergée sur IP 66.175.208[.]251, 69.164.216[.]69, 95.165.66[.]27. A amplifié premières opérations Storm-1516",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2023-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Infrastructure-Historique",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "deepstateleaks.org",
+    matchType: "exact",
+    reason: "Site CopyCop majeur. A publié deepfakes vocaux usurpant Barack OBAMA et David AXELROD (1er août 2024) concernant tentative assassinat Donald TRUMP",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-08-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Deepfakes-Audio",
+      "Élections-USA-2024",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "deinequellen.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop se présentant comme source d'information",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "democracydepth.com",
+    matchType: "exact",
+    reason: "Faux site d'analyse démocratique, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "democracydive.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience intéressée par démocratie américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "democracydrive.org",
+    matchType: "exact",
+    reason: "Faux site pro-démocratie du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "de-nachrichtenseite.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique allemand, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "desmoinesdefender.com",
+    matchType: "exact",
+    reason: "Faux média de Des Moines, Iowa, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "deutschenachrichtenstelle.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop se présentant comme agence d'information",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "deutsch-w.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique allemand, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "dhstalk.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant discussions politiques américaines",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "diamondadvertiser.com",
+    matchType: "exact",
+    reason: "Faux site publicitaire/média, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "diewahreseite.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop se présentant comme 'le vrai site'",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "disnitsa.com",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "doch-infomedia.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique allemand, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "dznachrichten.de",
+    matchType: "exact",
+    reason: "Faux site d'actualité allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "echozeit.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience allemande, exploité pour opérations élections allemandes 2025",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-11-19",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne",
+      "Élections-Allemagne-2025"
+    ]
+  },
+
+  {
+    domain: "edatew.com",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "einfachandersinfo.de",
+    matchType: "exact",
+    reason: "Site d'information allemand du réseau CopyCop se présentant comme 'simplement différent'",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "einmaleinsneu.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "elbevets.com",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "ensemble-24.fr",
+    matchType: "exact",
+    reason: "OPÉRATION MAJEURE - Typosquatting du site officiel de la coalition Ensemble (ensemble-2024.fr). Enregistré 19/06/2024, 11 jours après dissolution Assemblée nationale. Usurpation identité graphique. Proposait 'prime Macron' de 100€ en échange de vote. Hébergé IP 63.250.43[.]138-139 liées à berliner-wochenzeitung.de",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-06-19",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-France",
+      "Élections-Législatives-2024",
+      "Typosquatting",
+      "Usurpation-Identité",
+      "Fraude-Électorale"
+    ]
+  },
+
+  {
+    domain: "epochpost.org",
+    matchType: "exact",
+    reason: "Faux site d'information du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "expert-infomedien.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop se présentant comme expert média",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "f-aktuell.de",
+    matchType: "exact",
+    reason: "Site d'actualité inauthentique allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "falconeye.tech",
+    matchType: "exact",
+    reason: "Site lié aux activités professionnelles de John Mark DOUGAN. Hébergé sur infrastructure CopyCop (IP 95.165.66[.]27) avec bostontimes.com et veritecachee.fr",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Infrastructure"
+    ]
+  },
+
+  {
+    domain: "fcastro.ru",
+    matchType: "exact",
+    reason: "Site de la Fondation Fidel Castro créée par Léonid SAVINE (éditeur en chef de geopolitika.ru). Hébergé sur infrastructure CopyCop. Liens avec Valéry KOROVINE",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2021-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Écosystème-DOUGUINE",
+      "Léonid-SAVINE",
+      "Valéry-KOROVINE"
+    ]
+  },
+
+  {
+    domain: "flagstaffpost.com",
+    matchType: "exact",
+    reason: "Faux média local de Flagstaff, Arizona, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "flyoverbeacon.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant États américains du centre ('flyover states')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "flythesky.ru",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop avec extension .ru, administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2018-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN"
+    ]
+  },
+
+  {
+    domain: "foreignagentintel.com",
+    matchType: "exact",
+    reason: "Site hébergé par John Mark DOUGAN pour Mike JONES (influenceur américain pro-russe exilé en Russie) avant leur rupture",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2020-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Influenceurs-Pro-Russes"
+    ]
+  },
+
+  {
+    domain: "franceencolere.fr",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience française avec narratifs de colère et division",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-27",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-France"
+    ]
+  },
+
+  {
+    domain: "freedomfacade.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant audience américaine pro-liberté",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "freedomfixture.com",
+    matchType: "exact",
+    reason: "Faux site pro-liberté du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "freedomforge.info",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme forge de la liberté",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "freedomfoundry.info",
+    matchType: "exact",
+    reason: "Faux site liberté du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "freeeaglepress.org",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant thématique patriotique américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "fr-press.de",
+    matchType: "exact",
+    reason: "Site CopyCop allemand se présentant comme presse française",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "gaugerformayor.com",
+    matchType: "exact",
+    reason: "Site créé par John Mark DOUGAN pour se venger de personnes enquêtant sur ses activités",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Harcèlement"
+    ]
+  },
+
+  {
+    domain: "gbgeopolitics.com",
+    matchType: "exact",
+    reason: "Site géopolitique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "gegengewicht-media.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop se présentant comme contrepoids médiatique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "gegenleitmedien.de",
+    matchType: "exact",
+    reason: "Site CopyCop allemand contre 'Leitmedien' (médias dominants)",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "georgiagazette.us",
+    matchType: "exact",
+    reason: "Faux journal de Géorgie, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "gopguardian.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant Parti Républicain américain (GOP)",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "governancegaze.com",
+    matchType: "exact",
+    reason: "Faux site d'analyse gouvernance du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "greenmen-movement.com",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "guckmalgenauhin.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('regarde attentivement')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "hamb-post.de",
+    matchType: "exact",
+    reason: "Faux journal de Hambourg du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "hamburger-anzeiger.de",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant média hambourgeois",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "hamburger-sichtweisen.de",
+    matchType: "exact",
+    reason: "Faux site d'opinions hambourgeois, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "hamburg-ex.de",
+    matchType: "exact",
+    reason: "Site CopyCop de Hambourg",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "harrisburg-chronicle.com",
+    matchType: "exact",
+    reason: "Faux journal de Harrisburg, Pennsylvanie, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "heartlandharbor.org",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant Heartland américain",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "heartlandhaven.org",
+    matchType: "exact",
+    reason: "Faux site Heartland du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "heartlandheadlines.net",
+    matchType: "exact",
+    reason: "Site CopyCop d'actualités Heartland",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "heartlandherald.us",
+    matchType: "exact",
+    reason: "Faux journal du Heartland, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "heartland-inquirer.org",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant média du Heartland américain",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "herrpostillon.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "heute-inberlin.de",
+    matchType: "exact",
+    reason: "Faux site d'actualité berlinois du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "h-np.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique allemand, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "honestcitizens.org",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme plateforme citoyenne honnête",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "hotelpalacedesneiges.com",
+    matchType: "exact",
+    reason: "OPÉRATION SPÉCIFIQUE - Site créé pour fausse acquisition par ZELENSKY d'un hôtel à Courchevel. Hébergé IP 162.255.118[.]65-66, même cluster que seattle-tribune.com et wehrpflicht2025.de",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-11-25",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Opération-Spécifique",
+      "Anti-Ukraine",
+      "ZELENSKY"
+    ]
+  },
+
+  {
+    domain: "houstonpost.org",
+    matchType: "exact",
+    reason: "Faux journal de Houston du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "huawei-govno.ru",
+    matchType: "exact",
+    reason: "Site créé par John Mark DOUGAN pour critiquer entreprise Huawei ('govno' = merde en russe)",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN"
+    ]
+  },
+
+  {
+    domain: "in-absicht.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "infomediafuerdich.de",
+    matchType: "exact",
+    reason: "Site d'information allemand du réseau CopyCop ('info média pour toi')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "info-mediaplattform.de",
+    matchType: "exact",
+    reason: "Plateforme média inauthentique allemande du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "infomediaregierungskritisch.de",
+    matchType: "exact",
+    reason: "Site allemand CopyCop se présentant comme info média critique du gouvernement",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne",
+      "Anti-Gouvernement"
+    ]
+  },
+
+  {
+    domain: "informant-info.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "infosindependants.fr",
+    matchType: "exact",
+    reason: "OPÉRATION MAJEURE - Site français majeur du réseau CopyCop. Enregistré 27/01/2024. Hébergé IP 95.165.66[.]27 avec falconeye.tech, bostontimes.com et veritecachee.fr. A primo-diffusé opération 'pont Armée Rouge Paris' le 5/05/2024",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-27",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-France",
+      "Infrastructure-Clé",
+      "Primo-Diffusion"
+    ]
+  },
+
+  {
+    domain: "info-stichpunkt.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "ins-gesicht.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "internetpoebler-info.de",
+    matchType: "exact",
+    reason: "Site d'information allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "in-und-ausland.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('national et international')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "justiceserved.org",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant thématique justice américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "kbsf-tv.com",
+    matchType: "exact",
+    reason: "Faux site télévision américain du réseau CopyCop, exploité pour opérations électorales USA",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-08-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Élections-USA-2024"
+    ]
+  },
+
+  {
+    domain: "kernpunkt-infomedia.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('point central info média')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "kernrecht.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "klartext-news.de",
+    matchType: "exact",
+    reason: "Site d'actualité allemand du réseau CopyCop ('actualités franc-parler')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "konusnews.de",
+    matchType: "exact",
+    reason: "Site d'actualité inauthentique allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "kurzchronik.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('chronique courte')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "la-cher.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "lakestarreview.com",
+    matchType: "exact",
+    reason: "Faux média local américain du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "langmir.ru",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop avec extension .ru, administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2018-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN"
+    ]
+  },
+
+  {
+    domain: "lansingtribune.org",
+    matchType: "exact",
+    reason: "Faux journal de Lansing, Michigan, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "laut-medien.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('médias bruyants')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "leaderledger.net",
+    matchType: "exact",
+    reason: "Faux registre de leaders, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "leaveukrainewar.com",
+    matchType: "exact",
+    reason: "Site CopyCop propagande anti-Ukraine ('quitter la guerre d'Ukraine')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Anti-Ukraine",
+      "Propagande"
+    ]
+  },
+
+  {
+    domain: "lesechodelafrance.fr",
+    matchType: "exact",
+    reason: "Faux média français du réseau CopyCop ('l'écho de la France')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-27",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-France"
+    ]
+  },
+
+  {
+    domain: "libertylagoon.org",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant thématique liberté américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "libertylantern.org",
+    matchType: "exact",
+    reason: "Faux site liberté du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "libertylaunch.org",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme lancement de la liberté",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "libertylectern.org",
+    matchType: "exact",
+    reason: "Faux site tribune liberté du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "libertypressnews.com",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant presse liberté américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "libertyvoice.info",
+    matchType: "exact",
+    reason: "Faux site voix de la liberté, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "londonchronicle.news",
+    matchType: "exact",
+    reason: "Faux journal londonien du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-UK"
+    ]
+  },
+
+  {
+    domain: "londoncrier.co.uk",
+    matchType: "exact",
+    reason: "Site CopyCop enregistré en janvier 2024 par John Mark DOUGAN, usurpant média britannique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-UK"
+    ]
+  },
+
+  {
+    domain: "londoncrier.com",
+    matchType: "exact",
+    reason: "Extension .com du faux média londonien du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-UK"
+    ]
+  },
+
+  {
+    domain: "lonestarcrier.com",
+    matchType: "exact",
+    reason: "Faux média du Texas ('Lone Star State'), réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "ltcolstu.com",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "madison-gazette.org",
+    matchType: "exact",
+    reason: "Faux journal de Madison, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "media-transparent.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop se présentant comme média transparent",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "mehrstimmen.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('plus de voix')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "miamichron.com",
+    matchType: "exact",
+    reason: "Faux journal de Miami du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "michigantribune.org",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant tribune du Michigan",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "munchener-nachrichten.de",
+    matchType: "exact",
+    reason: "Faux site d'actualités munichoises du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "mytransitionua.org",
+    matchType: "exact",
+    reason: "OPÉRATION SPÉCIFIQUE - Site pro-transgenres ukrainien inauthentique. Enregistré 18/12/2023. Imputé avec confiance élevée au projet Lakhta. Amplifié via Storm-1516 fin décembre 2023. Coordination entre MOI",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2023-12-18",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Anti-Ukraine",
+      "Coordination-MOI"
+    ]
+  },
+
+  {
+    domain: "nachrichtendestages.de",
+    matchType: "exact",
+    reason: "Site d'actualité inauthentique allemand du réseau CopyCop ('actualités du jour')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "nachrichtenunabhaengig.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('actualités indépendantes')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "n-a-h.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "nationalcrier.com",
+    matchType: "exact",
+    reason: "Faux média national américain du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "nationalmatters.org",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant affaires nationales américaines",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "nationalnarrative.org",
+    matchType: "exact",
+    reason: "Faux site narratif national du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "nationnotebook.com",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme carnet de notes national",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "nebraskatruth.com",
+    matchType: "exact",
+    reason: "Site CopyCop historique ('vérité du Nebraska'). Enregistré 2018-2023. Hébergé IP 160.153.0[.]104, proche de newswayforward.us et newwayforward.vote (campagne Kamala HARRIS)",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2018-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Infrastructure-Historique",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "nevadaannouncer.com",
+    matchType: "exact",
+    reason: "Faux média du Nevada du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "nevadaannouncer.org",
+    matchType: "exact",
+    reason: "Extension .org du faux média du Nevada, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "newscenterpress.org",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme centre presse d'actualités",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "news-checker.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop se présentant comme vérificateur d'actualités",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "newsdesk.press",
+    matchType: "exact",
+    reason: "Site CopyCop historique alimenté par articles reformulés via IA générative. Créé entre 2017-2023",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2020-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Infrastructure-Historique",
+      "IA-Générative"
+    ]
+  },
+
+  {
+    domain: "newsfuereuch.de",
+    matchType: "exact",
+    reason: "Site d'actualité allemand du réseau CopyCop ('actualités pour vous')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "newsletters-berlin.de",
+    matchType: "exact",
+    reason: "Faux site newsletters berlinois du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "newsmacher.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('faiseurs d'actualités')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "newswichtig.de",
+    matchType: "exact",
+    reason: "Site d'actualité allemand du réseau CopyCop ('actualités importantes')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "newswayforward.us",
+    matchType: "exact",
+    reason: "OPÉRATION MAJEURE - Typosquatting du site de campagne de Kamala HARRIS. Enregistré 18/09/2024. Hébergé IP 160.153.0[.]225, proche de nebraskatruth.com, ensemble-24.fr, casinohotelvunipalacehotel.com",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-09-18",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Élections-USA-2024",
+      "Typosquatting",
+      "Kamala-HARRIS"
+    ]
+  },
+
+  {
+    domain: "newwayforward.vote",
+    matchType: "exact",
+    reason: "OPÉRATION MAJEURE - 2e typosquatting campagne Kamala HARRIS. Enregistré 24/09/2024. Hébergé IP 63.250.43[.]132-133, cluster CopyCop proche berliner-wochenzeitung.de",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-09-24",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Élections-USA-2024",
+      "Typosquatting",
+      "Kamala-HARRIS"
+    ]
+  },
+
+  {
+    domain: "niggar.tech",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "nnberlin.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique berlinois du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "northcarolinacourier.us",
+    matchType: "exact",
+    reason: "Faux journal de Caroline du Nord du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "novanachrichten.de",
+    matchType: "exact",
+    reason: "Site d'actualité inauthentique allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "nrtv.online",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "nudis-verbis.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "nynewsdaily.org",
+    matchType: "exact",
+    reason: "Faux quotidien new-yorkais du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "oakjournalnews.com",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant journal américain",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "oasisobserverpost.org",
+    matchType: "exact",
+    reason: "Faux site observateur du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "oasis-weekly-post.com",
+    matchType: "exact",
+    reason: "Site CopyCop hebdomadaire américain",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "oku-nachrichten.de",
+    matchType: "exact",
+    reason: "Site d'actualité inauthentique allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "onlinedaheim-24.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('en ligne à la maison 24h/24')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "onlineunterwegs.de",
+    matchType: "exact",
+    reason: "Site d'actualité allemand du réseau CopyCop ('en ligne en déplacement')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "oraclenews.org",
+    matchType: "exact",
+    reason: "Faux site d'actualités oracle du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "parler2.com",
+    matchType: "exact",
+    reason: "Site CopyCop imitant réseau social Parler",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "partyperspective.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant perspective partisane américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "patriotbeacon.us",
+    matchType: "exact",
+    reason: "Faux site patriote américain du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "patrioticpage.com",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant thématique patriotique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "patrioticparade.com",
+    matchType: "exact",
+    reason: "Faux site parade patriotique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "patrioticpioneer.com",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme pionnier patriotique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "patrioticpulse.info",
+    matchType: "exact",
+    reason: "Faux site pouls patriotique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "patriotvoicenews.com",
+    matchType: "exact",
+    reason: "OPÉRATION MAJEURE - Site CopyCop avec compte Rumble associé @patriotvoicenews. A primo-diffusé opération Kamala HARRIS / P.Diddy (500 000$). Domaine patriotvoicenews.com lié à CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-10-30",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Élections-USA-2024",
+      "Primo-Diffusion"
+    ]
+  },
+
+  {
+    domain: "pbsotalk.org",
+    matchType: "exact",
+    reason: "Site créé par John Mark DOUGAN pour se venger de personnes enquêtant sur ses activités. Typosquattait potentiellement PBS",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Harcèlement",
+      "Typosquatting"
+    ]
+  },
+
+  {
+    domain: "pennsylvaniamessenger.com",
+    matchType: "exact",
+    reason: "Faux messager de Pennsylvanie du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "phoenixpatriot.org",
+    matchType: "exact",
+    reason: "Site CopyCop patriote de Phoenix, Arizona",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "polemisch-infomedia.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop se présentant comme info média polémique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "policypaddock.com",
+    matchType: "exact",
+    reason: "Faux site analyse politique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "policypassage.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant discussion politique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "policypatch.com",
+    matchType: "exact",
+    reason: "Faux site politique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "policypath.org",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme chemin politique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "policypeak.org",
+    matchType: "exact",
+    reason: "Faux site sommet politique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "policyplatform.info",
+    matchType: "exact",
+    reason: "Site CopyCop plateforme politique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "policyporch.org",
+    matchType: "exact",
+    reason: "Faux site porche politique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "politicalpioneer.com",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme pionnier politique",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "politicalplot.org",
+    matchType: "exact",
+    reason: "Faux site intrigue politique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "politicalporch.com",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant discussions politiques",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "politicostream.com",
+    matchType: "exact",
+    reason: "Faux site flux politique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "presseneu.de",
+    matchType: "exact",
+    reason: "Site d'information allemand du réseau CopyCop ('presse nouvelle')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "prinzipienfest.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "proudamerican.cc",
+    matchType: "exact",
+    reason: "Site CopyCop ciblant patriotes américains",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "publicnewspaper.org",
+    matchType: "exact",
+    reason: "Faux journal public du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "pulsepress.org",
+    matchType: "exact",
+    reason: "Site CopyCop se présentant comme presse pouls",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "purplestatepost.com",
+    matchType: "exact",
+    reason: "Faux site États pivots américains du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "raleigh-herald.com",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant journal de Raleigh, Caroline du Nord",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "red-blue-tribune.com",
+    matchType: "exact",
+    reason: "Faux site tribune bipartisane du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "redo1776.com",
+    matchType: "exact",
+    reason: "Site CopyCop référence historique américaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "redstategazette.com",
+    matchType: "exact",
+    reason: "Faux site États rouges conservateurs du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "redstatereport.net",
+    matchType: "exact",
+    reason: "Site CopyCop rapport États conservateurs",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "republicrally.com",
+    matchType: "exact",
+    reason: "Faux site rassemblement républicain du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "republicrange.com",
+    matchType: "exact",
+    reason: "Site CopyCop gamme républicaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "republicregard.com",
+    matchType: "exact",
+    reason: "Faux site regard républicain du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "republicreview.net",
+    matchType: "exact",
+    reason: "Site CopyCop revue républicaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "republicripple.com",
+    matchType: "exact",
+    reason: "Faux site onde républicaine du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "republicroot.com",
+    matchType: "exact",
+    reason: "Site CopyCop racine républicaine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "republicroots.org",
+    matchType: "exact",
+    reason: "Faux site racines républicaines du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "republicrundown.com",
+    matchType: "exact",
+    reason: "Site CopyCop résumé républicain",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "resonieren.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('résonner')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "rightrealm.net",
+    matchType: "exact",
+    reason: "Faux site royaume de droite du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "rightresonance.org",
+    matchType: "exact",
+    reason: "Site CopyCop résonance de droite",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "rightreview.org",
+    matchType: "exact",
+    reason: "Faux site revue de droite du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "rightrevival.org",
+    matchType: "exact",
+    reason: "Site CopyCop renouveau de droite",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "rightrundown.com",
+    matchType: "exact",
+    reason: "Faux site résumé de droite du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "rightwingrev.com",
+    matchType: "exact",
+    reason: "Site CopyCop révolution aile droite",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Audience-Conservatrice"
+    ]
+  },
+
+  {
+    domain: "ruf-der-freiheit.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('appel de la liberté')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "rundumdieuhr-24.de",
+    matchType: "exact",
+    reason: "Site d'actualité allemand du réseau CopyCop ('24h/24')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "sag-das.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('dis-le')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "sanfranchron.com",
+    matchType: "exact",
+    reason: "Faux journal de San Francisco du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "sarahwestall.com",
+    matchType: "exact",
+    reason: "Site hébergé par John Mark DOUGAN pour Sarah WESTALL (influenceuse américaine pro-russe). WESTALL a donné plusieurs centaines de dollars à DOUGAN via Buymeacoffee",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2020-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Influenceurs-Pro-Russes"
+    ]
+  },
+
+  {
+    domain: "sarahwestall.org",
+    matchType: "exact",
+    reason: "Extension .org du site de Sarah WESTALL hébergé par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2020-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Influenceurs-Pro-Russes"
+    ]
+  },
+
+  {
+    domain: "scheinwerfen.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('projecteur')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "scopestory.com",
+    matchType: "exact",
+    reason: "Faux site histoire portée du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "seattle-tribune.com",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant tribune de Seattle. Hébergé IP 162.255.118[.]65-66, même cluster que hotelpalacedesneiges.com et wehrpflicht2025.de",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA",
+      "Infrastructure-Clé"
+    ]
+  },
+
+  {
+    domain: "seite-eins-nachrichten.de",
+    matchType: "exact",
+    reason: "Site d'actualité allemand du réseau CopyCop ('actualités page une')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "senatesight.com",
+    matchType: "exact",
+    reason: "Faux site vision Sénat du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "signaldaily.org",
+    matchType: "exact",
+    reason: "Site CopyCop signal quotidien",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "silverstatesignal.org",
+    matchType: "exact",
+    reason: "Faux signal de l'État d'argent (Nevada) du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "skryty.ru",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop avec extension .ru ('caché' en russe), administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2018-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN"
+    ]
+  },
+
+  {
+    domain: "soiij.org",
+    matchType: "exact",
+    reason: "Site de la fausse organisation 'Syndicate of Independent International Journalists' créée par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Fausse-Organisation"
+    ]
+  },
+
+  {
+    domain: "speech.chat",
+    matchType: "exact",
+    reason: "Forum créé par John Mark DOUGAN dans le réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2017-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN"
+    ]
+  },
+
+  {
+    domain: "statestage.org",
+    matchType: "exact",
+    reason: "Faux site scène étatique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "stimmedeutsch.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('voix allemande')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "suitreview.org",
+    matchType: "exact",
+    reason: "Site CopyCop revue costume",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "tageblatt-berlin.de",
+    matchType: "exact",
+    reason: "Faux quotidien berlinois du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "tagesnews-24.de",
+    matchType: "exact",
+    reason: "Site d'actualité 24h/24 allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "tagundnacht24.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('jour et nuit 24')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "thearizonaobserver.com",
+    matchType: "exact",
+    reason: "Faux observateur de l'Arizona du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "thegeorgiangazette.com",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant gazette georgienne",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "thegreenmen.org",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "thesis-info.de",
+    matchType: "exact",
+    reason: "Site d'information allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "timkirbyshow.com",
+    matchType: "exact",
+    reason: "Site hébergé par John Mark DOUGAN pour Tim KIRBY (influenceur américain pro-russe exilé en Russie). Locaux partagés au 11 allée Bryoussov, Moscou",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2020-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Influenceurs-Pro-Russes"
+    ]
+  },
+
+  {
+    domain: "todayschronicle.org",
+    matchType: "exact",
+    reason: "Faux chronique d'aujourd'hui du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "top-news-munchen.de",
+    matchType: "exact",
+    reason: "Site d'actualité inauthentique municho du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "tribunetimes.org",
+    matchType: "exact",
+    reason: "Site CopyCop usurpant tribune times",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "truthapedia.com",
+    matchType: "exact",
+    reason: "Faux site encyclopédie vérité du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "truthapedia.org",
+    matchType: "exact",
+    reason: "Extension .org de la fausse encyclopédie vérité, réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "truthcentral.org",
+    matchType: "exact",
+    reason: "Site CopyCop centrale vérité",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "turnsy.com",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "ukpoliticking.com",
+    matchType: "exact",
+    reason: "Faux site politique britannique du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-UK"
+    ]
+  },
+
+  {
+    domain: "ukrainepeace.org",
+    matchType: "exact",
+    reason: "Site CopyCop propagande 'paix en Ukraine' anti-soutien à l'Ukraine",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Anti-Ukraine",
+      "Propagande"
+    ]
+  },
+
+  {
+    domain: "ungeziert-info.de",
+    matchType: "exact",
+    reason: "Site d'information allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "unitytrend.com",
+    matchType: "exact",
+    reason: "Faux site tendance unité du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "unmittelbar-medien.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('média immédiat')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "vanguardviews.com",
+    matchType: "exact",
+    reason: "Site CopyCop vues avant-garde",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "veritecachee.fr",
+    matchType: "exact",
+    reason: "Site français majeur du réseau CopyCop ('vérité cachée'). Enregistré 22/06/2024. Hébergé IP 95.165.66[.]27 avec infosindependants.fr, falconeye.tech, bostontimes.com. Nom proche du faux média d'Adrien BOCQUET 'Vérités cachées'",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-06-22",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-France",
+      "Infrastructure-Clé",
+      "Adrien-BOCQUET"
+    ]
+  },
+
+  {
+    domain: "vidvist.com",
+    matchType: "exact",
+    reason: "Site du réseau CopyCop administré par John Mark DOUGAN",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "visionar-info.de",
+    matchType: "exact",
+    reason: "Site d'information allemand du réseau CopyCop ('visionnaire')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "vollverstand.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('pleine compréhension')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "votervista.net",
+    matchType: "exact",
+    reason: "Faux site vue électeur du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "w-a-munchen.de",
+    matchType: "exact",
+    reason: "Site d'information inauthentique municho du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "warstudiescentre.co.uk",
+    matchType: "exact",
+    reason: "OPÉRATION SPÉCIFIQUE - Site CopyCop usurpant identité graphique de l'Institute for the Study of War américain. Diffuse fausses citations militaires occidentaux concernant missiles russes Orechnik",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2025-01-09",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-UK",
+      "Usurpation-Identité",
+      "Opération-Spécifique"
+    ]
+  },
+
+  {
+    domain: "washingtonwatch.us",
+    matchType: "exact",
+    reason: "Site CopyCop surveillance Washington",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "wdr-hall.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop imitant potentiellement WDR",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "wehrpflicht2025.de",
+    matchType: "exact",
+    reason: "OPÉRATION MAJEURE - Site usurpant ministère Défense allemand. Affirmait recrutement 500 000 soldats pour 'maintenir paix en Europe de l'Est'. Enregistré novembre 2024. Hébergé IP 162.255.118[.]65-66, même cluster seattle-tribune.com et hotelpalacedesneiges.com",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-11-19",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne",
+      "Usurpation-Identité",
+      "Opération-Spécifique"
+    ]
+  },
+
+  {
+    domain: "weitwinkelmedien.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop ('média grand angle')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "woodlandweeklyguardian.com",
+    matchType: "exact",
+    reason: "Faux gardien hebdomadaire Woodland du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "worldnewsdesk.press",
+    matchType: "exact",
+    reason: "Site CopyCop bureau actualités mondiales",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop"
+    ]
+  },
+
+  {
+    domain: "wochenueberblick-berlin.de",
+    matchType: "contains",
+    reason: "Site CopyCop aperçu hebdomadaire Berlin (IDN avec caractère spécial)",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "xposedem.com",
+    matchType: "exact",
+    reason: "Site CopyCop anti-démocrates américains",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-10",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-USA"
+    ]
+  },
+
+  {
+    domain: "zeitenwende-news.de",
+    matchType: "exact",
+    reason: "Site d'actualité allemand du réseau CopyCop ('actualités tournant des temps')",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  {
+    domain: "zeitgeschenen.de",
+    matchType: "exact",
+    reason: "Site allemand du réseau CopyCop",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    reportUrl: "https://www.sgdsn.gouv.fr",
+    identifiedDate: "2024-01-01",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Sites-Allemagne"
+    ]
+  },
+
+  // ===== FIN DU RÉSEAU COPYCOP =====
+
+];
+
+// ===== COMPTES DE RÉSEAUX SOCIAUX STORM-1516 =====
+// Comptes identifiés pour primo-diffusion et amplification
+
+const storm1516SocialAccounts = [
+  
+  // ===== COMPTES X / TWITTER =====
+  
+  {
+    platform: "X/Twitter",
+    handle: "@AdrienBocquet59",
+    url: "https://x.com/AdrienBocquet59",
+    name: "Adrien BOCQUET",
+    role: "Primo-diffusion et amplification",
+    description: "Ancien militaire français exilé en Russie. Primo-diffuseur de narratifs Storm-1516, notamment opération accusant Léonid VOLKOV de trafic humain. Émission 'Vérités cachées'",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Primo-Diffusion",
+      "Amplification",
+      "Influenceur-France",
+      "Rémunéré"
+    ],
+    identifiedDate: "2024-03-02",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@AlertChannel",
+    url: "https://x.com/AlertChannel",
+    role: "Amplification",
+    description: "Compte exploité durant phase d'amplification. Rémunération probable par opérateurs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Réseau-Rémunéré"
+    ],
+    identifiedDate: "2024-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@Alphafox78",
+    url: "https://x.com/Alphafox78",
+    role: "Primo-diffusion et amplification",
+    description: "Compte ayant primo-diffusé vidéo 'Haïtiens votant illégalement pour HARRIS'. Administrateur avoue avoir été payé 100$ par Simeon BOÏKOV pour publications répétées",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Primo-Diffusion",
+      "Amplification",
+      "Rémunération-Avérée",
+      "Élections-USA-2024"
+    ],
+    identifiedDate: "2024-10-31",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    notes: "Preuve de rémunération directe par Simeon BOÏKOV"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@ANN_News92",
+    url: "https://x.com/ANN_News92",
+    role: "Amplification",
+    description: "Compte activé durant phase amplification. Schéma publication suggère rémunération",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification"
+    ],
+    identifiedDate: "2024-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@aussiecossack",
+    url: "https://x.com/aussiecossack",
+    name: "Simeon BOÏKOV",
+    role: "Coordination et amplification",
+    description: "ACTEUR CLÉ - Australien d'origine russe, réfugié consulat russe Sydney depuis déc. 2022. Lié à Fondation Combattre Injustice (FCI). COORDINATEUR rémunération influenceurs (a payé @Alphafox78 100$ par publication). Amplifie quasi-systématiquement narratifs Storm-1516",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Coordination",
+      "Amplification",
+      "Galaxie-PRIGOJINE",
+      "FCI",
+      "Rémunérateur"
+    ],
+    identifiedDate: "2024-03-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    notes: "Coordinateur confirmé du réseau de rémunération. Exilé consulat russe Sydney"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@BPartisans",
+    url: "https://x.com/BPartisans",
+    role: "Amplification - Audience francophone",
+    description: "Compte francophone pro-russe amplifiant narratifs Storm-1516. Remercié par faux lanceur 'Jules Vincent' (opération SOROS/déchets toxiques Ukraine)",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Pro-Russe-France"
+    ],
+    identifiedDate: "2023-11-27",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@camaradamachado",
+    url: "https://x.com/camaradamachado",
+    name: "Raphael MACHADO",
+    role: "Amplification",
+    description: "Président organisation nationaliste brésilienne Nova Resistência, proche DOUGUINE. Amplifié 8+ opérations Storm-1516 (août 2023-janvier 2025)",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Écosystème-DOUGUINE",
+      "Nova-Resistência",
+      "Brésil"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@camille_moscow",
+    url: "https://x.com/camille_moscow",
+    role: "Reprises opportunistes",
+    description: "Compte francophone pro-russe relayant quasi-systématiquement narratifs Storm-1516",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Reprises",
+      "Pro-Russe-France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@ChayBowes",
+    url: "https://x.com/ChayBowes",
+    name: "Chay BOWES",
+    role: "Amplification systématique",
+    description: "ACTEUR MAJEUR - Journaliste pro-russe origine irlandaise, ex-RT, réside en Russie. Amplifie PRESQUE TOUS narratifs Storm-1516 quelques heures après primo-diffusion. Lié à FCI et BJA (BRICS Journalist Association). Site: theislander.eu",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Galaxie-PRIGOJINE",
+      "FCI",
+      "BJA",
+      "Irlande"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    relatedSites: ["theislander.eu"]
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@daniel_gugger",
+    url: "https://x.com/daniel_gugger",
+    role: "Amplification",
+    description: "Compte exploité durant phase amplification",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@DD_Geopolitics",
+    url: "https://x.com/DD_Geopolitics",
+    role: "Amplification",
+    description: "Compte géopolitique amplifiant narratifs Storm-1516. Rémunération probable",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@gheliason",
+    url: "https://x.com/gheliason",
+    name: "George ELIASON",
+    role: "Amplification",
+    description: "Amplificateur actif narratifs Storm-1516. Lié écosystème FCI/BJA",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "FCI"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@IslanderReports",
+    url: "https://x.com/IslanderReports",
+    name: "Chay BOWES (compte secondaire)",
+    role: "Amplification",
+    description: "Compte Substack de Chay BOWES (islanderreports.substack.com). Amplifie narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "FCI",
+      "BJA"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    relatedSites: ["islanderreports.substack.com"]
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@its_The_Dr",
+    url: "https://x.com/its_The_Dr",
+    role: "Amplification",
+    description: "Compte amplifiant narratifs Storm-1516",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@janus_putkonen",
+    url: "https://x.com/janus_putkonen",
+    name: "Janus PUTKONEN",
+    role: "Amplification",
+    description: "Éditeur en chef mvlehti.net (Finlande). Amplifie narratifs Storm-1516. Lié FCI/BJA",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "FCI",
+      "Finlande"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    relatedSites: ["mvlehti.net"]
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@JimFergusonUK",
+    url: "https://x.com/JimFergusonUK",
+    role: "Amplification",
+    description: "Compte UK amplifiant narratifs Storm-1516",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "UK"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@JovicaJovic15",
+    url: "https://x.com/JovicaJovic15",
+    name: "Jovica JOVIC",
+    role: "Amplification",
+    description: "Amplifie narratifs Storm-1516. Lié écosystème FCI",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "FCI"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@leiroz_lucas",
+    url: "https://x.com/leiroz_lucas",
+    name: "Lucas LEIROZ",
+    role: "Amplification",
+    description: "Membre Nova Resistência (Brésil), proche DOUGUINE. Bureau BJA (BRICS Journalist Association). Collabore avec Inforos (GRU unité 54777). Amplifié 8+ opérations Storm-1516 (août 2023-janvier 2025)",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Écosystème-DOUGUINE",
+      "Nova-Resistência",
+      "BJA",
+      "GRU-54777",
+      "Brésil"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@MattMetro",
+    url: "https://x.com/MattMetro",
+    name: "Matthew METRO (deepfake)",
+    role: "Primo-diffusion - Identité usurpée",
+    description: "OPÉRATION DEEPFAKE - Compte créé octobre 2023 usurpant identité Matthew METRO (élève lycée). Deepfake accuse Timothy WALTZ agression sexuelle 1997. Traits visage probablement usurpés depuis photos réseaux sociaux",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Primo-Diffusion",
+      "Deepfake",
+      "Identité-Usurpée",
+      "Élections-USA-2024"
+    ],
+    identifiedDate: "2024-10-16",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    notes: "Deepfake confirmé usurpant identité personne réelle"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@MichelMichaelW1",
+    url: "https://x.com/MichelMichaelW1",
+    name: "Michael WITTWER",
+    role: "Amplification - Audience germanophone",
+    description: "Ancien candidat parti extrême-droite Pro Chemnitz (Allemagne). Recruté pour crédibiliser narratifs auprès audience germanophone",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Allemagne",
+      "Extrême-Droite"
+    ],
+    identifiedDate: "2024-11-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@MiraMiru4",
+    url: "https://x.com/MiraMiru4",
+    name: "Mira TERADA (alias Oksana VOVK)",
+    role: "Amplification - FCI",
+    description: "ACTRICE MAJEURE - Gérante Fondation pour Combattre l'Injustice (FCI) et BRICS Journalist Association (BJA), galaxie PRIGOJINE. Ressortissante russe, incarcérée 2 ans USA pour blanchiment. Quasi tous narratifs Storm-1516 amplifiés par réseau FCI/BJA",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Galaxie-PRIGOJINE",
+      "FCI",
+      "BJA",
+      "Coordination"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    notes: "Dirigeante FCI et BJA - organisations clés amplification"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@MyLordBebo",
+    url: "https://x.com/MyLordBebo",
+    role: "Amplification",
+    description: "Compte amplifiant narratifs Storm-1516",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@ReadeAlexandra",
+    url: "https://x.com/ReadeAlexandra",
+    name: "Alexandra READE",
+    role: "Amplification",
+    description: "Exilée en Russie depuis 2023. Amplifie narratifs Storm-1516. Lié FCI/BJA",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "FCI",
+      "Exilée-Russie"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@simonateba",
+    url: "https://x.com/simonateba",
+    role: "Amplification",
+    description: "Compte amplifiant narratifs Storm-1516",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@SonjaEnde",
+    url: "https://x.com/SonjaEnde",
+    name: "Sonja VAN DER ENDE",
+    role: "Amplification",
+    description: "Néerlandaise. Administratrice devend.online. Amplifie narratifs Storm-1516. Lié FCI/BJA",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "FCI",
+      "Pays-Bas"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    relatedSites: ["devend.online"]
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@TheWakeninq",
+    url: "https://x.com/TheWakeninq",
+    role: "Primo-diffusion et amplification - USA",
+    description: "Influenceur américain pro-MAGA recruté par Storm-1516 pour primo-diffuser narratifs ciblant élection présidentielle USA 2024. Rémunération probable",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Primo-Diffusion",
+      "Amplification",
+      "Élections-USA-2024",
+      "Pro-MAGA"
+    ],
+    identifiedDate: "2024-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@vtforeignpolicy",
+    url: "https://x.com/vtforeignpolicy",
+    role: "Amplification",
+    description: "Compte amplifiant narratifs Storm-1516. Site associé: vtforeignpolicy.com",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    relatedSites: ["vtforeignpolicy.com"]
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@Zlatti_71",
+    url: "https://x.com/Zlatti_71",
+    role: "Amplification",
+    description: "Compte amplifiant narratifs Storm-1516",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  // ===== COMPTES X - PROJET LAKHTA =====
+  // Comptes liés au projet Lakhta participant à Storm-1516
+
+  {
+    platform: "X/Twitter",
+    handle: "@patriotesunis1",
+    url: "https://x.com/patriotesunis1",
+    role: "Primo-diffusion et amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta. Primo-diffusé vidéo migrant tchadien relâché (23 déc 2024), puis amplifié avec publications sponsorisées 26 déc",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Primo-Diffusion",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-12-23",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    notes: "Coordination avérée Storm-1516 / Lakhta"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@gaulliste_92",
+    url: "https://x.com/gaulliste_92",
+    role: "Primo-diffusion - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta. Primo-diffuseur narratifs Storm-1516",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Primo-Diffusion",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    notes: "Coordination avérée Storm-1516 / Lakhta"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@patriotes2Fr",
+    url: "https://x.com/patriotes2Fr",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta. Amplifié avec publications sponsorisées vidéo migrant tchadien 26 déc 2024",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-12-26",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@enfrancetoday",
+    url: "https://x.com/enfrancetoday",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta amplifiant narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@JaimemaFra94466",
+    url: "https://x.com/JaimemaFra94466",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta amplifiant narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@PourFrance39064",
+    url: "https://x.com/PourFrance39064",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta amplifiant narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@AvenirDeFrance",
+    url: "https://x.com/AvenirDeFrance",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta amplifiant narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@ActusFrance24",
+    url: "https://x.com/ActusFrance24",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta amplifiant narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@ActusContinu",
+    url: "https://x.com/ActusContinu",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta amplifiant narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@ActuReel",
+    url: "https://x.com/ActuReel",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta amplifiant narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "X/Twitter",
+    handle: "@infosPR23",
+    url: "https://x.com/infosPR23",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Compte francophone lié projet Lakhta amplifiant narratifs Storm-1516",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  // ===== COMPTES TELEGRAM =====
+
+  {
+    platform: "Telegram",
+    handle: "@AussieCossack",
+    url: "t.me/AussieCossack",
+    name: "Simeon BOÏKOV",
+    role: "Coordination et amplification",
+    description: "ACTEUR CLÉ - Canal Telegram de Simeon BOÏKOV. Coordination rémunération influenceurs. Amplifie quasi-systématiquement narratifs Storm-1516",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Coordination",
+      "Amplification",
+      "Galaxie-PRIGOJINE",
+      "FCI"
+    ],
+    identifiedDate: "2024-03-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "Telegram",
+    handle: "@BadVolfNews",
+    url: "t.me/BadVolfNews",
+    name: "John Mark DOUGAN",
+    role: "Amplification - CopyCop",
+    description: "INFRASTRUCTURE CLÉ - Canal Telegram de John Mark DOUGAN. Au moins 3 opérations Storm-1516 amplifiées directement sur ce canal",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "John-Mark-DOUGAN",
+      "Amplification"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "Telegram",
+    handle: "@boriskarpovrussie",
+    url: "t.me/boriskarpovrussie",
+    role: "Reprises opportunistes - France",
+    description: "Canal francophone pro-russe relayant narratifs Storm-1516",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Reprises",
+      "France"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "Telegram",
+    handle: "@golosmordora",
+    url: "t.me/golosmordora",
+    role: "Amplification russophone - Projet Lakhta",
+    description: "LIEN LAKHTA - Canal PRINCIPAL primo-diffusion narratifs Storm-1516 auprès audience russophone. Répertorié parmi 'bloggeurs' agence RIA FAN (groupe Patriot PRIGOJINE)",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Galaxie-PRIGOJINE",
+      "Amplification",
+      "Audience-Russophone"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    notes: "Canal clé diffusion audience russophone - lien RIA FAN"
+  },
+
+  {
+    platform: "Telegram",
+    handle: "@michel_mickael_wittwer",
+    url: "t.me/michel_mickael_wittwer",
+    name: "Michael WITTWER",
+    role: "Amplification - Allemagne",
+    description: "Canal de Michael WITTWER, ancien candidat Pro Chemnitz. Amplifie narratifs Storm-1516 audience germanophone",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Allemagne",
+      "Extrême-Droite"
+    ],
+    identifiedDate: "2024-11-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "Telegram",
+    handle: "@neuesausrussland",
+    url: "t.me/neuesausrussland",
+    name: "Alina LIPP",
+    role: "Amplification - Allemagne",
+    description: "Canal d'Alina LIPP, allemande pro-russe. Amplifie narratifs Storm-1516 auprès audience germanophone. Lié FCI/BJA",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "FCI",
+      "BJA",
+      "Allemagne"
+    ],
+    identifiedDate: "2024-01-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "Telegram",
+    handle: "@radiostydoba",
+    url: "t.me/radiostydoba",
+    role: "Amplification russophone - Projet Lakhta",
+    description: "LIEN LAKHTA - Canal amplifiant narratifs Storm-1516 auprès audience russophone. Mentionné dans Wagner Leaks comme rémunéré pour publications",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "Audience-Russophone",
+      "Rémunéré"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    notes: "Rémunération documentée dans Wagner Leaks"
+  },
+
+  {
+    platform: "Telegram",
+    handle: "@sanya_florida",
+    url: "t.me/sanya_florida",
+    role: "Amplification russophone",
+    description: "Canal amplifiant narratifs Storm-1516 auprès audience russophone. Suit fréquemment @golosmordora",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Audience-Russophone"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "Telegram",
+    handle: "@warhistoryalconafter",
+    url: "t.me/warhistoryalconafter",
+    role: "Amplification russophone",
+    description: "Canal amplifiant narratifs Storm-1516 auprès audience russophone",
+    riskLevel: "medium",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Amplification",
+      "Audience-Russophone"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  // ===== COMPTES YOUTUBE =====
+  // Comptes jetables et lanceurs d'alerte fictifs
+
+  {
+    platform: "YouTube",
+    handle: "@Ibrahimabiola668",
+    url: "youtube.com/@Ibrahimabiola668",
+    role: "Primo-diffusion - Compte jetable",
+    description: "OPÉRATION PRINCE ANDREW - Compte jetable exploité pour opération accusant prince Andrew agression sexuelle et enlèvement enfants ukrainiens. Mise en scène 'Mr. James O.' témoin visuel",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Primo-Diffusion",
+      "Compte-Jetable"
+    ],
+    identifiedDate: "2023-08-27",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  {
+    platform: "YouTube",
+    handle: "@johndoe__2023",
+    url: "youtube.com/@johndoe__2023",
+    role: "Primo-diffusion - Compte jetable",
+    description: "Compte jetable Storm-1516. Toujours accessible à date malgré exposition publique",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Primo-Diffusion",
+      "Compte-Jetable"
+    ],
+    identifiedDate: "2023-08-01",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  // ===== COMPTES FACEBOOK =====
+
+  {
+    platform: "Facebook",
+    handle: "Ma France, Mon amour",
+    url: "facebook.com/ads/library/?id=1057518095586240",
+    role: "Amplification - Projet Lakhta",
+    description: "LIEN LAKHTA - Page Facebook liée projet Lakhta. Amplifié narratif migrant tchadien via publications sponsorisées",
+    riskLevel: "high",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "Projet-Lakhta",
+      "Amplification",
+      "France",
+      "Publicités-Sponsorisées"
+    ],
+    identifiedDate: "2024-12-26",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025"
+  },
+
+  // ===== COMPTES RUMBLE =====
+
+  {
+    platform: "Rumble",
+    handle: "@patriotvoicenews",
+    url: "rumble.com/c/patriotvoicenews",
+    role: "Primo-diffusion - CopyCop",
+    description: "LIEN COPYCOP - Compte Rumble lié domaine patriotvoicenews.com du réseau CopyCop. Primo-diffusé vidéo HARRIS/P.Diddy (500 000$)",
+    riskLevel: "critical",
+    tags: [
+      "STORM-1516",
+      "Russie",
+      "CopyCop",
+      "Primo-Diffusion",
+      "Élections-USA-2024"
+    ],
+    identifiedDate: "2024-10-30",
+    source: "VIGINUM - Rapport Storm-1516 Mai 2025",
+    relatedDomains: ["patriotvoicenews.com"]
+  }
+
+];
+
+// ===== FONCTIONS UTILITAIRES - DOMAINES =====
+
+// Filtrer par tag
+function filterStorm1516ByTag(tag) {
+  return storm1516Domains.filter(d => d.tags.includes(tag));
+}
+
+// Filtrer par niveau de risque
+function filterStorm1516ByRiskLevel(level) {
+  return storm1516Domains.filter(d => d.riskLevel === level);
+}
+
+// Obtenir tous les tags uniques
+function getStorm1516Tags() {
+  const allTags = new Set();
+  storm1516Domains.forEach(d => {
+    d.tags.forEach(tag => allTags.add(tag));
+  });
+  return Array.from(allTags).sort();
+}
+
+// Obtenir les statistiques
+function getStorm1516Stats() {
+  return {
+    total: storm1516Domains.length,
+    critical: storm1516Domains.filter(d => d.riskLevel === "critical").length,
+    highRisk: storm1516Domains.filter(d => d.riskLevel === "high").length,
+    mediumRisk: storm1516Domains.filter(d => d.riskLevel === "medium").length,
+    lowRisk: storm1516Domains.filter(d => d.riskLevel === "low").length,
+    tags: getStorm1516Tags()
+  };
+}
+
+// Obtenir par catégorie
+function getStorm1516ByCategory() {
+  const categories = {
+    copycop: storm1516Domains.filter(d => d.tags.includes("CopyCop")),
+    france: storm1516Domains.filter(d => d.tags.includes("Sites-France")),
+    usa: storm1516Domains.filter(d => d.tags.includes("Sites-USA")),
+    allemagne: storm1516Domains.filter(d => d.tags.includes("Sites-Allemagne")),
+    uk: storm1516Domains.filter(d => d.tags.includes("Sites-UK")),
+    operationsSpecifiques: storm1516Domains.filter(d => d.tags.includes("Opération-Spécifique")),
+    elections: storm1516Domains.filter(d => 
+      d.tags.some(tag => tag.includes("Élections") || tag.includes("Campagne"))
+    ),
+    infrastructure: storm1516Domains.filter(d => 
+      d.tags.includes("Infrastructure") || 
+      d.tags.includes("Infrastructure-Clé") || 
+      d.tags.includes("Infrastructure-Historique")
+    ),
+    acteurs: storm1516Domains.filter(d => 
+      d.tags.includes("John-Mark-DOUGAN") || 
+      d.tags.includes("Valéry-KOROVINE") ||
+      d.tags.includes("Adrien-BOCQUET")
+    )
+  };
+  
+  return categories;
+}
+
+// ===== FONCTIONS UTILITAIRES - COMPTES RÉSEAUX SOCIAUX =====
+
+// Filtrer comptes par plateforme
+function filterStorm1516AccountsByPlatform(platform) {
+  return storm1516SocialAccounts.filter(a => a.platform === platform);
+}
+
+// Filtrer comptes par rôle
+function filterStorm1516AccountsByRole(role) {
+  return storm1516SocialAccounts.filter(a => a.role && a.role.toLowerCase().includes(role.toLowerCase()));
+}
+
+// Filtrer comptes par niveau de risque
+function filterStorm1516AccountsByRiskLevel(level) {
+  return storm1516SocialAccounts.filter(a => a.riskLevel === level);
+}
+
+// Filtrer comptes par tag
+function filterStorm1516AccountsByTag(tag) {
+  return storm1516SocialAccounts.filter(a => a.tags.includes(tag));
+}
+
+// Obtenir statistiques comptes réseaux sociaux
+function getStorm1516AccountsStats() {
+  const platforms = {};
+  const riskLevels = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0
+  };
+  
+  storm1516SocialAccounts.forEach(account => {
+    // Compter par plateforme
+    if (!platforms[account.platform]) {
+      platforms[account.platform] = 0;
+    }
+    platforms[account.platform]++;
+    
+    // Compter par niveau de risque
+    if (riskLevels[account.riskLevel] !== undefined) {
+      riskLevels[account.riskLevel]++;
+    }
+  });
+  
+  return {
+    total: storm1516SocialAccounts.length,
+    platforms: platforms,
+    riskLevels: riskLevels,
+    acteursCles: storm1516SocialAccounts.filter(a => a.description && a.description.includes("ACTEUR CLÉ")).length,
+    acteursMajeurs: storm1516SocialAccounts.filter(a => a.description && a.description.includes("ACTEUR MAJEUR")).length,
+    lakhta: storm1516SocialAccounts.filter(a => a.tags.includes("Projet-Lakhta")).length,
+    copycop: storm1516SocialAccounts.filter(a => a.tags.includes("CopyCop")).length,
+    fci: storm1516SocialAccounts.filter(a => a.tags.includes("FCI")).length,
+    remunerationAveree: storm1516SocialAccounts.filter(a => a.tags.includes("Rémunération-Avérée")).length
+  };
+}
+
+// Obtenir acteurs clés
+function getStorm1516KeyActors() {
+  return storm1516SocialAccounts.filter(a => 
+    a.riskLevel === "critical" || 
+    (a.description && (a.description.includes("ACTEUR CLÉ") || a.description.includes("ACTEUR MAJEUR")))
+  );
+}
+
+// Rechercher comptes par nom
+function searchStorm1516Accounts(searchTerm) {
+  const term = searchTerm.toLowerCase();
+  return storm1516SocialAccounts.filter(a => 
+    (a.handle && a.handle.toLowerCase().includes(term)) ||
+    (a.name && a.name.toLowerCase().includes(term)) ||
+    (a.description && a.description.toLowerCase().includes(term))
+  );
+}
+
+// Obtenir comptes liés à des élections
+function getStorm1516ElectionAccounts() {
+  return storm1516SocialAccounts.filter(a => 
+    a.tags.some(tag => tag.includes("Élections"))
+  );
+}
+
+// Obtenir comptes par pays/région
+function getStorm1516AccountsByCountry(country) {
+  const countryTag = country.charAt(0).toUpperCase() + country.slice(1).toLowerCase();
+  return storm1516SocialAccounts.filter(a => 
+    a.tags.some(tag => tag.includes(countryTag))
+  );
+}
+
+// Export pour Node.js / modules
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    // Données
+    storm1516Domains,
+    storm1516SocialAccounts,
+    
+    // Fonctions domaines
+    filterStorm1516ByTag,
+    filterStorm1516ByRiskLevel,
+    getStorm1516Tags,
+    getStorm1516Stats,
+    getStorm1516ByCategory,
+    
+    // Fonctions comptes réseaux sociaux
+    filterStorm1516AccountsByPlatform,
+    filterStorm1516AccountsByRole,
+    filterStorm1516AccountsByRiskLevel,
+    filterStorm1516AccountsByTag,
+    getStorm1516AccountsStats,
+    getStorm1516KeyActors,
+    searchStorm1516Accounts,
+    getStorm1516ElectionAccounts,
+    getStorm1516AccountsByCountry
+  };
+}
+
+// Disponibilité globale pour le navigateur
+if (typeof window !== 'undefined') {
+  window.storm1516Domains = storm1516Domains;
+  window.storm1516SocialAccounts = storm1516SocialAccounts;
+  
+  window.Storm1516Utils = {
+    // Domaines
+    filterByTag: filterStorm1516ByTag,
+    filterByRiskLevel: filterStorm1516ByRiskLevel,
+    getTags: getStorm1516Tags,
+    getStats: getStorm1516Stats,
+    getByCategory: getStorm1516ByCategory,
+    
+    // Comptes réseaux sociaux
+    filterAccountsByPlatform: filterStorm1516AccountsByPlatform,
+    filterAccountsByRole: filterStorm1516AccountsByRole,
+    filterAccountsByRiskLevel: filterStorm1516AccountsByRiskLevel,
+    filterAccountsByTag: filterStorm1516AccountsByTag,
+    getAccountsStats: getStorm1516AccountsStats,
+    getKeyActors: getStorm1516KeyActors,
+    searchAccounts: searchStorm1516Accounts,
+    getElectionAccounts: getStorm1516ElectionAccounts,
+    getAccountsByCountry: getStorm1516AccountsByCountry
+  };
+}
+
+// Log de chargement
+console.log(`=== STORM-1516 BASE DE DONNÉES CHARGÉE ===`);
+console.log(`Domaines: ${storm1516Domains.length} identifiés`);
+console.log(`Comptes réseaux sociaux: ${storm1516SocialAccounts.length} identifiés`);
+
+if (storm1516Domains.length > 0) {
+  console.log("\n--- Statistiques Domaines ---");
+  console.log(getStorm1516Stats());
+  const categories = getStorm1516ByCategory();
+  console.log("\nCatégories:", Object.keys(categories).map(key => `${key}: ${categories[key].length}`));
+}
+
+if (storm1516SocialAccounts.length > 0) {
+  console.log("\n--- Statistiques Comptes Réseaux Sociaux ---");
+  console.log(getStorm1516AccountsStats());
+  console.log(`\nActeurs clés identifiés: ${getStorm1516KeyActors().length}`);
+}

--- a/plugin/plugin_chrome/releases/Plugin-dima/data/databases/TemplateOPS.js
+++ b/plugin/plugin_chrome/releases/Plugin-dima/data/databases/TemplateOPS.js
@@ -1,0 +1,169 @@
+// DIMA - Template pour nouvelle base de données d'opération
+// REMPLACEZ "OPERATION_NAME" par le nom de votre opération (ex: Doppelganger, Portal_Kombat, etc.)
+
+/**
+ * INSTRUCTIONS D'UTILISATION
+ * ==========================
+ * 
+ * 1. Copiez ce fichier et renommez-le (ex: Doppelganger.js)
+ * 2. Remplacez tous les "OPERATION_NAME" par le nom de l'opération
+ * 3. Remplissez les domaines dans le tableau
+ * 4. Chargez ce fichier AVANT suspiciousSites.js dans votre HTML
+ * 
+ * EXEMPLE:
+ * <script src="data/Copycop.js"></script>
+ * <script src="data/Doppelganger.js"></script>
+ * <script src="data/suspiciousSites.js"></script>
+ */
+
+// Nom de la variable globale (à adapter selon votre opération)
+// Exemples:
+// - copycopDomains (déjà existant)
+// - doppelgangerDomains
+// - portalKombatDomains
+// - yourOperationDomains
+
+const OPERATION_NAMEDomains = [
+  // ===== EXEMPLE D'ENTRÉE =====
+  {
+    domain: "example-fake-news.com",
+    matchType: "exact", // "exact", "contains", ou "pattern"
+    reason: "Site identifié dans l'opération [NOM], diffusant de la désinformation ciblée",
+    source: "Nom de l'organisation source (ex: EU DisinfoLab, DFRLab, etc.)",
+    reportUrl: "https://lien-vers-le-rapport-complet.com",
+    identifiedDate: "2025-01-15", // Format: YYYY-MM-DD
+    riskLevel: "high", // "high", "medium", ou "low"
+    tags: [
+      "OPERATION_NAME", // Tag obligatoire : nom de l'opération
+      "Russie", // Origine géographique si connue
+      "USA", // Pays ciblé
+      "Anti-Ukraine", // Thématique
+      "Élections" // Type de campagne
+    ]
+  },
+
+  // ===== AJOUTEZ VOS DOMAINES ICI =====
+  
+  /*
+  // Template à copier pour chaque nouveau domaine:
+  {
+    domain: "votre-domaine.com",
+    matchType: "exact",
+    reason: "Description précise de la raison",
+    source: "Organisation source",
+    reportUrl: "https://...",
+    identifiedDate: "YYYY-MM-DD",
+    riskLevel: "high|medium|low",
+    tags: ["OPERATION_NAME", "tag1", "tag2"]
+  },
+  */
+
+];
+
+// =============================================================================
+// FONCTIONS UTILITAIRES (OPTIONNELLES)
+// =============================================================================
+
+/**
+ * Ces fonctions sont optionnelles mais recommandées pour faciliter
+ * l'utilisation de votre base de données indépendamment du gestionnaire principal
+ */
+
+// Filtrer par tag
+function filterOPERATION_NAMEByTag(tag) {
+  return OPERATION_NAMEDomains.filter(d => d.tags.includes(tag));
+}
+
+// Filtrer par niveau de risque
+function filterOPERATION_NAMEByRiskLevel(level) {
+  return OPERATION_NAMEDomains.filter(d => d.riskLevel === level);
+}
+
+// Obtenir tous les tags uniques
+function getOPERATION_NAMETags() {
+  const allTags = new Set();
+  OPERATION_NAMEDomains.forEach(d => {
+    d.tags.forEach(tag => allTags.add(tag));
+  });
+  return Array.from(allTags).sort();
+}
+
+// Obtenir les statistiques
+function getOPERATION_NAMEStats() {
+  return {
+    total: OPERATION_NAMEDomains.length,
+    highRisk: OPERATION_NAMEDomains.filter(d => d.riskLevel === "high").length,
+    mediumRisk: OPERATION_NAMEDomains.filter(d => d.riskLevel === "medium").length,
+    lowRisk: OPERATION_NAMEDomains.filter(d => d.riskLevel === "low").length,
+    tags: getOPERATION_NAMETags()
+  };
+}
+
+// =============================================================================
+// EXPORTS ET DISPONIBILITÉ GLOBALE
+// =============================================================================
+
+// Export pour Node.js / modules
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    OPERATION_NAMEDomains,
+    filterOPERATION_NAMEByTag,
+    filterOPERATION_NAMEByRiskLevel,
+    getOPERATION_NAMETags,
+    getOPERATION_NAMEStats
+  };
+}
+
+// Disponibilité globale pour le navigateur
+if (typeof window !== 'undefined') {
+  window.OPERATION_NAMEDomains = OPERATION_NAMEDomains;
+  window.OPERATION_NAMEUtils = {
+    filterByTag: filterOPERATION_NAMEByTag,
+    filterByRiskLevel: filterOPERATION_NAMEByRiskLevel,
+    getTags: getOPERATION_NAMETags,
+    getStats: getOPERATION_NAMEStats
+  };
+}
+
+// Log de chargement
+console.log(`Liste OPERATION_NAME chargée: ${OPERATION_NAMEDomains.length} domaines identifiés`);
+if (OPERATION_NAMEDomains.length > 0) {
+  console.log("Statistiques OPERATION_NAME:", getOPERATION_NAMEStats());
+}
+
+// =============================================================================
+// GUIDE DES TAGS RECOMMANDÉS
+// =============================================================================
+
+/**
+ * TAGS OBLIGATOIRES:
+ * - Le nom de votre opération (ex: "Doppelganger", "Portal_Kombat")
+ * 
+ * TAGS GÉOGRAPHIQUES (origine):
+ * - Russie, Chine, Iran, Corée_du_Nord, etc.
+ * 
+ * TAGS GÉOGRAPHIQUES (cible):
+ * - USA, France, Canada, UK, Allemagne, Ukraine, etc.
+ * - Sites-US, Sites-France, Sites-Canada (pour collections de sites locaux)
+ * 
+ * TAGS THÉMATIQUES:
+ * - Anti-Ukraine
+ * - Élections
+ * - COVID-19
+ * - Climat
+ * - Immigration
+ * - Santé
+ * 
+ * TAGS TECHNIQUES:
+ * - LLM (contenu généré par IA)
+ * - Deepfake
+ * - Usurpation-Identité
+ * - Bot-Network
+ * - Infrastructure
+ * 
+ * TAGS DE MÉTHODE:
+ * - Désinformation-Ciblée
+ * - Amplification-Artificielle
+ * - Multi-Langues
+ * - Coordination-Cross-Platform
+ */

--- a/plugin/plugin_chrome/releases/Plugin-dima/manifest.json
+++ b/plugin/plugin_chrome/releases/Plugin-dima/manifest.json
@@ -20,6 +20,7 @@
         "data/databases/PortalKombat.js",
         "data/databases/RRN.js",
         "data/databases/Baybridge.js",
+        "data/databases/Storm1516.js",
         "data/techniques.js",
         "data/keywords.js",
         "modules/contentExtractor.js",

--- a/plugin/plugin_chrome/releases/Plugin-dima/manifest.json
+++ b/plugin/plugin_chrome/releases/Plugin-dima/manifest.json
@@ -1,23 +1,37 @@
 {
   "manifest_version": 3,
-  "name": "Analyseur DIMA - M82 Project",
-  "version": "1.1",
-  "description": "Plugin d'analyse de manipulation cognitive selon la matrice DIMA par M82 Project",
-  "permissions": ["activeTab", "storage"],
+  "name": "DIMA - Digital Influence Manipulation Analyzer",
+  "version": "2.0.0",
+  "description": "Plugin d'analyse de manipulation cognitive selon la matrice DIMA par M82 Project, détecte et analyse les sites suspects identifiés dans des rapports de désinformation",
+  "permissions": [
+    "activeTab",
+    "storage"
+  ],
+  
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
       "js": [
+        "data/databases/Copycop.js",
+        "data/databases/PortalKombat.js",
+        "data/databases/RRN.js",
         "data/techniques.js",
         "data/keywords.js",
         "modules/contentExtractor.js",
+        "modules/suspiciousSitesManager.js",
         "modules/techniqueAnalyzer.js",
         "modules/uiManager.js",
         "content.js"
-      ]
+      ],
+      "run_at": "document_end"
     }
   ],
-  "action": {
+  
+ "action": {
     "default_title": "Analyse DIMA - M82 Project"
   },
   "icons": {

--- a/plugin/plugin_chrome/releases/Plugin-dima/manifest.json
+++ b/plugin/plugin_chrome/releases/Plugin-dima/manifest.json
@@ -19,6 +19,7 @@
         "data/databases/Copycop.js",
         "data/databases/PortalKombat.js",
         "data/databases/RRN.js",
+        "data/databases/Baybridge.js",
         "data/techniques.js",
         "data/keywords.js",
         "modules/contentExtractor.js",

--- a/plugin/plugin_chrome/releases/Plugin-dima/modules/Suspicioussitesmanager.js
+++ b/plugin/plugin_chrome/releases/Plugin-dima/modules/Suspicioussitesmanager.js
@@ -1,0 +1,310 @@
+// DIMA - Gestionnaire Central de Sites Suspects
+// Ce fichier charge et agrège toutes les bases de données de domaines suspects
+
+/**
+ * Gestionnaire centralisé des sites suspects
+ * Charge automatiquement toutes les bases de données disponibles
+ * et fournit une API unifiée pour vérifier les sites
+ */
+class SuspiciousSitesManager {
+  constructor() {
+    this.sources = new Map();
+    this.allSites = [];
+    this.stats = {
+      totalSites: 0,
+      byRiskLevel: { high: 0, medium: 0, low: 0 },
+      bySources: {},
+      byTags: {}
+    };
+    
+    this.init();
+  }
+
+  /**
+   * Initialise le gestionnaire en chargeant toutes les sources disponibles
+   */
+  init() {
+    console.log('🛡️ DIMA: Initialisation du gestionnaire de sites suspects...');
+    
+    // Détecter et charger les sources disponibles
+    this.detectAndLoadSources();
+    
+    // Agréger tous les sites
+    this.aggregateAllSites();
+    
+    // Calculer les statistiques
+    this.calculateStats();
+    
+    console.log(`✅ DIMA: ${this.allSites.length} sites suspects chargés depuis ${this.sources.size} source(s)`);
+    this.logStats();
+  }
+
+  /**
+   * Détecte et charge automatiquement toutes les sources disponibles
+   */
+  detectAndLoadSources() {
+    // Source 1: CopyCop (Recorded Future)
+    if (typeof copycopDomains !== 'undefined' && Array.isArray(copycopDomains)) {
+      this.registerSource('CopyCop', copycopDomains, {
+        name: 'Opération CopyCop',
+        description: 'Réseau russe de sites fictifs et de désinformation',
+        organization: 'Recorded Future - Insikt Group',
+        reportUrl: 'https://www.recordedfuture.com/research/cta-ru-2025-0917',
+        reportDate: '2025-09-17'
+      });
+      console.log(`  ✓ Source CopyCop chargée: ${copycopDomains.length} domaines`);
+    }
+
+    // Source 2: RRN (VIGINUM)
+    if (typeof rrnDomains !== 'undefined' && Array.isArray(rrnDomains)) {
+      this.registerSource('RRN', rrnDomains, {
+        name: 'Réseau RRN',
+        description: 'Réseau de faux médias et infrastructure de désinformation pro-russe',
+        organization: 'VIGINUM',
+        reportUrl: 'https://www.sgdsn.gouv.fr/files/files/20230619_NP_VIGINUM_RAPPORT-CAMPAGNE-RRN_VF_0.pdf',
+        reportDate: '2023-06-19'
+      });
+      console.log(`  ✓ Source RRN chargée: ${rrnDomains.length} domaines`);
+    }
+
+    // Source 3: Doppelganger (à venir)
+    if (typeof doppelgangerDomains !== 'undefined' && Array.isArray(doppelgangerDomains)) {
+      this.registerSource('Doppelganger', doppelgangerDomains, {
+        name: 'Opération Doppelganger',
+        description: 'Sites usurpant l\'identité de médias légitimes',
+        organization: 'À définir',
+        reportUrl: '',
+        reportDate: ''
+      });
+      console.log(`  ✓ Source Doppelganger chargée: ${doppelgangerDomains.length} domaines`);
+    }
+
+    // Source 4: Portal Kombat (à venir)
+    if (typeof portalKombatDomains !== 'undefined' && Array.isArray(portalKombatDomains)) {
+      this.registerSource('PortalKombat', portalKombatDomains, {
+        name: 'Opération Portal Kombat',
+        description: 'Réseau d\'influence',
+        organization: 'À définir',
+        reportUrl: '',
+        reportDate: ''
+      });
+      console.log(`  ✓ Source Portal Kombat chargée: ${portalKombatDomains.length} domaines`);
+    }
+
+    // Avertissement si aucune source n'est chargée
+    if (this.sources.size === 0) {
+      console.warn('⚠️  DIMA: Aucune base de données de sites suspects n\'a été chargée');
+      console.warn('   Vérifiez que les fichiers de bases de données sont correctement chargés avant ce gestionnaire');
+    }
+  }
+
+  /**
+   * Enregistre une nouvelle source de données
+   */
+  registerSource(sourceName, domains, metadata) {
+    this.sources.set(sourceName, {
+      domains: domains,
+      metadata: metadata,
+      count: domains.length
+    });
+  }
+
+  /**
+   * Agrège tous les sites de toutes les sources
+   */
+  aggregateAllSites() {
+    this.allSites = [];
+    
+    for (const [sourceName, sourceData] of this.sources) {
+      this.allSites.push(...sourceData.domains);
+    }
+  }
+
+  /**
+   * Calcule les statistiques globales
+   */
+  calculateStats() {
+    this.stats.totalSites = this.allSites.length;
+    
+    // Reset stats
+    this.stats.byRiskLevel = { high: 0, medium: 0, low: 0 };
+    this.stats.bySources = {};
+    this.stats.byTags = {};
+    
+    // Compter par niveau de risque et tags
+    this.allSites.forEach(site => {
+      // Par niveau de risque
+      if (site.riskLevel) {
+        this.stats.byRiskLevel[site.riskLevel] = (this.stats.byRiskLevel[site.riskLevel] || 0) + 1;
+      }
+      
+      // Par source
+      if (site.source) {
+        this.stats.bySources[site.source] = (this.stats.bySources[site.source] || 0) + 1;
+      }
+      
+      // Par tags
+      if (site.tags && Array.isArray(site.tags)) {
+        site.tags.forEach(tag => {
+          this.stats.byTags[tag] = (this.stats.byTags[tag] || 0) + 1;
+        });
+      }
+    });
+  }
+
+  /**
+   * Affiche les statistiques dans la console
+   */
+  logStats() {
+    console.log('📊 Statistiques:');
+    console.log(`   Total: ${this.stats.totalSites} sites`);
+    console.log(`   Risque élevé: ${this.stats.byRiskLevel.high || 0}`);
+    console.log(`   Risque moyen: ${this.stats.byRiskLevel.medium || 0}`);
+    console.log(`   Risque faible: ${this.stats.byRiskLevel.low || 0}`);
+    console.log(`   Sources: ${Object.keys(this.stats.bySources).length}`);
+  }
+
+  /**
+   * Vérifie si une URL correspond à un site suspect
+   * @param {string} url - L'URL à vérifier
+   * @returns {Object} Résultat de la vérification
+   */
+  checkSite(url) {
+    try {
+      const urlObj = new URL(url);
+      const hostname = urlObj.hostname.toLowerCase();
+      
+      for (const site of this.allSites) {
+        let isMatch = false;
+        
+        switch (site.matchType) {
+          case "exact":
+            isMatch = hostname === site.domain.toLowerCase() || 
+                     hostname === `www.${site.domain.toLowerCase()}`;
+            break;
+            
+          case "contains":
+            isMatch = hostname.includes(site.domain.toLowerCase());
+            break;
+            
+          case "pattern":
+            try {
+              const regex = new RegExp(site.domain, "i");
+              isMatch = regex.test(hostname);
+            } catch (e) {
+              console.error(`DIMA: Pattern regex invalide pour ${site.domain}:`, e);
+            }
+            break;
+        }
+        
+        if (isMatch) {
+          return {
+            isSuspicious: true,
+            siteInfo: site,
+            riskConfig: this.getRiskConfig(site.riskLevel),
+            matchedHostname: hostname
+          };
+        }
+      }
+      
+      return { isSuspicious: false };
+    } catch (error) {
+      console.error("DIMA: Erreur lors de la vérification du site suspect:", error);
+      return { isSuspicious: false, error: error.message };
+    }
+  }
+
+  /**
+   * Retourne la configuration visuelle pour un niveau de risque
+   */
+  getRiskConfig(riskLevel) {
+    const RISK_LEVELS = {
+      high: {
+        color: "#c0392b",
+        icon: "⚠️",
+        label: "Risque Élevé",
+        message: "Ce site a été identifié comme diffusant de la désinformation de manière systématique."
+      },
+      medium: {
+        color: "#e67e22",
+        icon: "⚡",
+        label: "Vigilance Requise",
+        message: "Ce site a été signalé pour des pratiques douteuses."
+      },
+      low: {
+        color: "#f39c12",
+        icon: "ℹ️",
+        label: "À Surveiller",
+        message: "Ce site présente des caractéristiques suspectes."
+      }
+    };
+    
+    return RISK_LEVELS[riskLevel] || RISK_LEVELS.low;
+  }
+
+  /**
+   * Retourne les statistiques
+   */
+  getStats() {
+    return this.stats;
+  }
+
+  /**
+   * Retourne les informations sur toutes les sources chargées
+   */
+  getSourcesInfo() {
+    const sourcesInfo = [];
+    for (const [sourceName, sourceData] of this.sources) {
+      sourcesInfo.push({
+        name: sourceName,
+        count: sourceData.count,
+        ...sourceData.metadata
+      });
+    }
+    return sourcesInfo;
+  }
+
+  /**
+   * Recherche des sites par tag
+   */
+  searchByTag(tag) {
+    return this.allSites.filter(site => 
+      site.tags && site.tags.includes(tag)
+    );
+  }
+
+  /**
+   * Recherche des sites par source
+   */
+  searchBySource(sourceName) {
+    return this.allSites.filter(site => 
+      site.source === sourceName
+    );
+  }
+}
+
+// Initialisation automatique du gestionnaire
+let suspiciousSitesManager;
+
+// Initialiser après le chargement de toutes les bases de données
+if (typeof window !== 'undefined') {
+  // Dans le navigateur, initialiser après un court délai pour laisser les autres fichiers se charger
+  setTimeout(() => {
+    suspiciousSitesManager = new SuspiciousSitesManager();
+    
+    // Rendre disponible globalement
+    window.suspiciousSitesManager = suspiciousSitesManager;
+    
+    // Pour compatibilité avec l'ancien code, exposer aussi checkSuspiciousSite
+    window.checkSuspiciousSite = (url) => suspiciousSitesManager.checkSite(url);
+    
+    // Exposer aussi les statistiques et infos
+    window.getSuspiciousSitesStats = () => suspiciousSitesManager.getStats();
+    window.getSuspiciousSitesSourcesInfo = () => suspiciousSitesManager.getSourcesInfo();
+  }, 100);
+}
+
+// Export pour Node.js si nécessaire
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = SuspiciousSitesManager;
+}

--- a/plugin/plugin_chrome/releases/Plugin-dima/modules/Suspicioussitesmanager.js
+++ b/plugin/plugin_chrome/releases/Plugin-dima/modules/Suspicioussitesmanager.js
@@ -67,30 +67,30 @@ class SuspiciousSitesManager {
       console.log(`  ✓ Source RRN chargée: ${rrnDomains.length} domaines`);
     }
 
-    // Source 3: Doppelganger (à venir)
-    if (typeof doppelgangerDomains !== 'undefined' && Array.isArray(doppelgangerDomains)) {
-      this.registerSource('Doppelganger', doppelgangerDomains, {
-        name: 'Opération Doppelganger',
-        description: 'Sites usurpant l\'identité de médias légitimes',
-        organization: 'À définir',
-        reportUrl: '',
-        reportDate: ''
-      });
-      console.log(`  ✓ Source Doppelganger chargée: ${doppelgangerDomains.length} domaines`);
-    }
-
-    // Source 4: Portal Kombat (à venir)
+    // Source 3: Portal Kombat (VIGINUM)
     if (typeof portalKombatDomains !== 'undefined' && Array.isArray(portalKombatDomains)) {
       this.registerSource('PortalKombat', portalKombatDomains, {
         name: 'Opération Portal Kombat',
         description: 'Réseau d\'influence',
-        organization: 'À définir',
-        reportUrl: '',
-        reportDate: ''
+        organization: 'Viginum',
+        reportUrl: 'https://www.sgdsn.gouv.fr/files/files/20240212_NP_SGDSN_VIGINUM_RAPPORT-RESEAU-PORTAL-KOMBAT_VF.pdf',
+        reportDate: '2024-02-01'
       });
       console.log(`  ✓ Source Portal Kombat chargée: ${portalKombatDomains.length} domaines`);
     }
 
+    // Source 4: Baybridge (IRSEM)
+    if (typeof baybridgeDomains !== 'undefined' && Array.isArray(baybridgeDomains)) {
+      this.registerSource('Baybridge', baybridgeDomains, {
+        name: 'Opération Baybridge',
+        description: 'Vaste écosystème d\'influence informationnelle chinoise ',
+        organization: 'IRSEM & TadaWeb',
+        reportUrl: 'https://www.irsem.fr/focus',
+        reportDate: '2025-10-17'
+      });
+      console.log(`  ✓ Source Baybridge chargée: ${baybridgeDomains.length} domaines`);
+    }
+    
     // Avertissement si aucune source n'est chargée
     if (this.sources.size === 0) {
       console.warn('⚠️  DIMA: Aucune base de données de sites suspects n\'a été chargée');


### PR DESCRIPTION
Ajouts de databases sur les sites inventoriés dans rapports de désinfo. Ui Manager modifié pour intégrer un test sur l'URL et comparaison présence du site dans database.