### PR TITLE
feat: SPA navigator + GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "DETECT/**"
+      - "INFORM/**"
+      - "MEMORISE/**"
+      - "ACT/**"
+      - "src/dima_convert.py"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Regenerate JSON data from Markdown
+        run: uv run src/dima_convert.py md2json --all -o docs/data
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/data/ACT.json
+++ b/docs/data/ACT.json
@@ -1,0 +1,385 @@
+{
+  "phase": "ACT",
+  "tactics": [
+    {
+      "id": "TA0041",
+      "separator": " ",
+      "name": "Valorisation individuelle",
+      "techniques": [
+        {
+          "id": "TE0411",
+          "separator": " : ",
+          "name": "biais d'excès de confiance",
+          "description": "Surestimation de ses propres capacités ou connaissances conduisant à des prises de décision trop rapides ou insuffisamment réfléchies.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Vous êtes assez intelligent pour comprendre\"",
+                "\"Avec vos compétences, c'est évident\"",
+                "\"Vous savez mieux que quiconque ce qu'il faut faire\""
+              ]
+            }
+          ]
+        },
+        {
+          "id": "TE0412",
+          "separator": " : ",
+          "name": "Effet Peltzman (compensation du risque)",
+          "description": "Tendance à prendre plus de risques lorsqu'on se sent protégé ou en sécurité, compensant ainsi les mesures de sécurité mises en place.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Avec cette protection, vous pouvez y aller sans crainte\"",
+                "\"C'est sécurisé, alors n'hésitez pas\"",
+                "\"Le système vous protège, foncez\""
+              ]
+            }
+          ]
+        },
+        {
+          "id": "TE0413",
+          "separator": " : ",
+          "name": "Supériorité illusoire",
+          "description": "Conviction d'être meilleur, plus intelligent ou plus compétent que la moyenne, créant une confiance excessive dans ses propres jugements.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Vous n'êtes pas comme les autres\"",
+                "\"Vous êtes au-dessus de la moyenne\"",
+                "\"Les gens ordinaires ne comprennent pas, mais vous si\""
+              ]
+            }
+          ]
+        },
+        {
+          "id": "TE0414",
+          "separator": " : ",
+          "name": "FOMO (fear of missing out)",
+          "description": "Technique qui exploite une forme d'anxiété sociale caractérisée par la peur constante de manquer une nouvelle importante ou tout autre événement donnant une occasion d'interagir socialement. Cette peur de \"rater quelque chose\" incite à agir, et interagir avec les contenus.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Ne ratez pas cette opportunité unique\"",
+                "\"Tout le monde en parle, rejoignez le mouvement\"",
+                "\"Dernière chance de participer\""
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "Tactique qui valorisent le jugement personnel et la confiance en soi.",
+      "sections": []
+    },
+    {
+      "id": "TA0042",
+      "separator": " ",
+      "name": "Renforcement escalatoire",
+      "techniques": [
+        {
+          "id": "TE0421",
+          "separator": " : ",
+          "name": "biais des coûts irrécupérables",
+          "description": "Tendance à continuer une activité ou un investissement en raison des ressources (temps, argent, effort) déjà investies, même si l'abandon serait plus rationnel.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Après tout le temps qu'on y a passé, on ne peut pas abandonner\"",
+                "\"Vu l'argent déjà investi, il faut continuer\"",
+                "\"Trop tard pour faire marche arrière maintenant\""
+              ]
+            },
+            {
+              "title": "Références",
+              "items": [
+                "Principe fondamental en économie comportementale",
+                "Lié à l'aversion aux pertes (Kahneman & Tversky)"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "TE0422",
+          "separator": " : ",
+          "name": "biais d'autorité",
+          "description": "Tendance à accorder plus de crédibilité ou à suivre les directives de personnes perçues comme étant en position d'autorité, même quand ces directives sont questionnables.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Les experts recommandent...\"",
+                "\"Selon les autorités...\"",
+                "\"Des spécialistes renommés affirment...\""
+              ]
+            },
+            {
+              "title": "Références",
+              "items": [
+                "Expérience de Milgram (1963)",
+                "Principe d'autorité de Cialdini"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "TE0423",
+          "separator": " : ",
+          "name": "Biais de la preuve sociale artificielle",
+          "description": "Tendance des individus à adopter les comportements des autres en situation d'incertitude. La preuve sociale artificielle cherche à exploiter cette tendance en donnant l'illusion d'un consencus ou d'un comportement massivement partagé.\nCréation d'une illusion de consensus ou de popularité pour influencer la décision individuelle. Exploitation du fait que les gens ont tendance à suivre les actions de la masse.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Des millions de personnes nous font confiance\"",
+                "\"Le plus populaire de sa catégorie\"",
+                "\"Tout le monde utilise ce produit/service\"",
+                "\"Tendance virale sur les réseaux\""
+              ]
+            },
+            {
+              "title": "Références",
+              "items": [
+                "Principe de preuve sociale de Cialdini",
+                "Expériences d'Asch sur le conformisme (1951)"
+              ]
+            },
+            {
+              "title": "Note",
+              "text": "Différent de la preuve sociale authentique - ici il y a manipulation ou fabrication des données de popularité."
+            }
+          ]
+        },
+        {
+          "id": "TE0424",
+          "separator": " : ",
+          "name": "Biais de rareté",
+          "description": "Valorisation accrue d'une opportunité ou d'un objet perçu comme rare, limité ou difficile à obtenir. La perception de rareté crée un sentiment d'urgence et pousse à l'action immédiate.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Stock limité : plus que 3 articles disponibles\"",
+                "\"Offre valable pour les 50 premiers clients\"",
+                "\"Édition limitée numérotée\"",
+                "\"Tant que les stocks durent\"",
+                "\"Accès exclusif réservé aux membres\""
+              ]
+            },
+            {
+              "title": "Fondements psychologiques",
+              "items": [
+                "Principe de rareté de Cialdini (1984)",
+                "Théorie de la réactance psychologique (Brehm, 1966)",
+                "Aversion aux pertes (Kahneman & Tversky)"
+              ]
+            },
+            {
+              "title": "Références",
+              "items": [
+                "Cialdini, R. B. (2006). *Influence: The Psychology of Persuasion*",
+                "Worchel, S., Lee, J., & Adewole, A. (1975). \"Effects of supply and demand on ratings of object value\"",
+                "Lynn, M. (1991). \"Scarcity effects on value: A quantitative review\""
+              ]
+            },
+            {
+              "title": "Contextes fréquents",
+              "items": [
+                "Marketing et e-commerce",
+                "Collecte de fonds",
+                "Propagande politique (\"dernière chance de sauver...\")",
+                "Manipulation sectaire (\"accès limité à la connaissance\")"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "TE0425",
+          "separator": " : ",
+          "name": "Pied dans la porte",
+          "description": "Obtenir d'abord un petit engagement initial (facile, peu coûteux) pour ensuite solliciter un engagement plus important. La personne ayant accepté la première demande sera plus encline à accepter la seconde par besoin de cohérence comportementale.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Commencez par un essai gratuit sans engagement\"",
+                "\"Il suffit de créer un compte - c'est rapide\"",
+                "\"Première étape : inscrivez-vous simplement\"",
+                "\"Juste regarder ne vous engage à rien\"",
+                "\"Testez gratuitement pendant 7 jours\""
+              ]
+            },
+            {
+              "title": "Fondements psychologiques",
+              "items": [
+                "Étude fondatrice: Freedman & Fraser (1966)",
+                "Principe de cohérence (Cialdini)",
+                "Théorie de l'auto-perception (Bem, 1972)",
+                "Escalade d'engagement progressive"
+              ]
+            },
+            {
+              "title": "Références",
+              "items": [
+                "Freedman, J. L., & Fraser, S. C. (1966). \"Compliance without pressure: The foot-in-the-door technique\". *Journal of Personality and Social Psychology*, 4(2), 195-202",
+                "Burger, J. M. (1999). \"The foot-in-the-door compliance procedure: A multiple-process analysis and review\". *Personality and Social Psychology Review*, 3(4), 303-325"
+              ]
+            },
+            {
+              "title": "Processus type",
+              "text": "1. Demande initiale minime (acceptée facilement)\n2. Sentiment d'engagement/cohérence créé\n3. Demande progressive plus importante\n4. Acceptation facilitée par besoin de cohérence"
+            },
+            {
+              "title": "Contextes fréquents",
+              "items": [
+                "Marketing digital (compte gratuit → essai → abonnement)",
+                "Recrutement sectaire (conférence → weekend → engagement total)",
+                "Propagande politique (pétition → meeting → militantisme)",
+                "Collecte de fonds (micro-don → don régulier → engagement majeur)"
+              ]
+            },
+            {
+              "title": "Technique opposée",
+              "text": "Porte au nez (Door-in-the-face) - demande énorme refusée suivie d'une demande raisonnable."
+            }
+          ]
+        },
+        {
+          "id": "TE0426",
+          "separator": " : ",
+          "name": "Biais de réciprocité",
+          "description": "Sentiment psychologique d'obligation de rendre une faveur, un cadeau ou un service reçu, même s'il n'a pas été sollicité. Cette norme sociale universelle est exploitée pour créer une dette psychologique qui pousse la personne à agir en retour.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Après tout ce qu'on a fait pour vous\"",
+                "\"On vous a offert X gratuitement, maintenant...\"",
+                "\"Nous vous avons aidé, à votre tour de nous soutenir\"",
+                "\"En retour, vous pourriez faire ce petit geste\"",
+                "\"C'est la moindre des choses après ce qu'on vous a donné\""
+              ]
+            },
+            {
+              "title": "Fondements psychologiques",
+              "items": [
+                "Premier principe de Cialdini (le plus puissant)",
+                "Norme sociale universelle (Gouldner, 1960)",
+                "Dette sociale et obligation psychologique",
+                "Réciprocité souvent disproportionnée"
+              ]
+            },
+            {
+              "title": "Références",
+              "items": [
+                "Cialdini, R. B. (2006). *Influence: The Psychology of Persuasion*",
+                "Gouldner, A. W. (1960). \"The norm of reciprocity: A preliminary statement\". *American Sociological Review*, 25(2), 161-178",
+                "Regan, D. T. (1971). \"Effects of a favor and liking on compliance\". *Journal of Experimental Social Psychology*, 7(6), 627-639"
+              ]
+            },
+            {
+              "title": "Mécanismes",
+              "text": "1. Don initial (sollicité ou non)\n2. Création d'une dette psychologique\n3. Malaise si \"dette\" non remboursée\n4. Pression pour agir en retour (souvent disproportionnée)"
+            },
+            {
+              "title": "Contextes fréquents",
+              "items": [
+                "Marketing (échantillons gratuits → achat)",
+                "Collecte de fonds (cadeau dans courrier → don)",
+                "Propagande (\"on vous a défendus → soutenez-nous\")",
+                "Manipulation sectaire (aide initiale → engagement total)",
+                "Contexte professionnel (\"j'ai couvert ton absence...\")"
+              ]
+            },
+            {
+              "title": "Signes de manipulation",
+              "items": [
+                "Don non sollicité créant dette artificielle",
+                "Rappels constants de ce qui a été donné",
+                "Culpabilisation si refus",
+                "Demande disproportionnée par rapport au don"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "Tactique qui favorise la réalisation d'actions déjà engagées.",
+      "sections": []
+    },
+    {
+      "id": "TA0043",
+      "separator": " : ",
+      "name": "Ozaekomi waza (contrôle par immobilisation)",
+      "techniques": [
+        {
+          "id": "TE0431",
+          "separator": " : ",
+          "name": "Biais d'omission",
+          "description": "Le biais d'omission consiste à considérer que causer éventuellement un tort par une action est pire que causer un tort par l'inaction. Ainsi, le biais d'omission pourrait contribuer à expliquer que, dans l'incertitude, certains choisiront de refuser la vaccination pour leurs enfants.",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Ne rien faire est plus sûr\"",
+                "\"Mieux vaut laisser faire les choses naturellement\"",
+                "\"L'inaction évite les erreurs\""
+              ]
+            },
+            {
+              "title": "Référence",
+              "text": "<https://www.psychomedia.qc.ca/psychologie/biais-cognitifs>"
+            }
+          ]
+        },
+        {
+          "id": "TE0432",
+          "separator": " : ",
+          "name": "Biais du statu quo",
+          "description": "Le biais de statu quo est la tendance à préférer laisser les choses telles qu'elles sont, un changement apparaissant comme apportant plus de risques et d'inconvénients que d'avantages possibles. Dans divers domaines, ce biais explique des choix qui ne sont pas les plus rationnels. (Un biais se rapprochant du biais de statu quo est celui de la tendance à la justification du système.)",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "\"Restons-en là, c'est plus sûr\"",
+                "\"Mieux vaut ne pas changer ce qui marche\"",
+                "\"Le changement est trop risqué\""
+              ]
+            },
+            {
+              "title": "Référence",
+              "text": "<https://www.psychomedia.qc.ca/psychologie/biais-cognitifs>"
+            }
+          ]
+        },
+        {
+          "id": "TE0433",
+          "separator": " : ",
+          "name": "Saturation informationnelle",
+          "description": "Technique qui consiste à saturer la cible d'information afin de limiter sa capacité de traitement et in fine paralyser la décision.\n\nLa saturation informationnelle vise à déclencher le processus de \"paralysie de l'analyse\".",
+          "sections": [
+            {
+              "title": "Exemples",
+              "items": [
+                "Trop d'options présentées simultanément",
+                "Informations contradictoires en masse",
+                "Complexité artificielle créant confusion"
+              ]
+            },
+            {
+              "title": "Références",
+              "items": [
+                "<https://fourweekmba.com/fr/paralysie-d%27analyse/>",
+                "<https://www.psychomedia.qc.ca/>"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "Tactique qui consiste à favoriser chez une cible, l'immobilisme et l'absence d'action.",
+      "sections": []
+    }
+  ]
+}

--- a/docs/data/DETECT.json
+++ b/docs/data/DETECT.json
@@ -1,0 +1,134 @@
+{
+  "phase": "DETECT",
+  "tactics": [
+    {
+      "id": "TA0011",
+      "separator": ": ",
+      "name": "Information préexistante",
+      "techniques": [
+        {
+          "id": "TE0111",
+          "separator": ": ",
+          "name": "Heuristique de disponibilité",
+          "description": "L’heuristique de disponibilité est un biais cognitif par lequel vous prenez une décision sur la base d’un exemple, d’une information ou d’une expérience récente qui vous est facilement accessible, même si ce n’est pas le meilleur exemple pour éclairer votre décision (Tversky & Kahneman, 1973).\nhttps://mentorshow.com/blog/heuristique-de-disponibilite",
+          "sections": []
+        },
+        {
+          "id": "TE0332",
+          "separator": ": ",
+          "name": "Effet de simple exposition",
+          "description": "Décrit par Robert Zajonc (1968), l’effet de simple exposition est un type de biais cognitif qui se caractérise par une augmentation de la probabilité d’avoir un sentiment positif envers quelqu’un ou quelque chose par la simple exposition répétée à cette personne ou cet objet.\nsource : https://monpsychomag.com/index.php/2021/11/05/cest-quoi-leffet-de-simple-exposition-en-psychologie/\n\nhttps://fr.wikipedia.org/wiki/",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui utilise des informations préexistantes ou des croyances établies pour capter l’attention de la cible.",
+      "sections": []
+    },
+    {
+      "id": "TA0012",
+      "separator": ": ",
+      "name": "Information à exposition répétée",
+      "techniques": [
+        {
+          "id": "TE0121",
+          "separator": ": ",
+          "name": "Illusion de la fréquence",
+          "description": "Autrement connu sous le nom de phénomène Baader-Meinhof, l'illusion de la fréquence semble être une combinaison de plusieurs biais qui nous amène à pratiquer une forme \"d'attention sélective\".\nCe mécanisme est particulièrement à l’œuvre dans la diffusion des thèses complotistes.\n\n\"L'illusion de fréquence consiste, après avoir remarqué une chose une première fois, à avoir tendance à la remarquer plus souvent, ce qui conduit à croire qu'elle se produit plus fréquemment qu'auparavant.\"\n\nsource : https://www.psychomedia.qc.ca/psychologie/biais-cognitifs",
+          "sections": []
+        },
+        {
+          "id": "TE0122",
+          "separator": ": ",
+          "name": "Effet de contexte",
+          "description": "Tendance à analyser une perception par rapport à des situation proches ou similaires.\n\nhttps://en.wikipedia.org/wiki/Context_effect",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui repose sur l’exploitation de la répétition de l’information en vue de faciliter sa détection par la cible.",
+      "sections": []
+    },
+    {
+      "id": "TA0013",
+      "separator": ": ",
+      "name": "Information clivante",
+      "techniques": [
+        {
+          "id": "TE0131",
+          "separator": ": ",
+          "name": "Effet de bizarrerie",
+          "description": "Tactique qui utilise la tendance à remarquer plus facilement les choses étranges.",
+          "sections": []
+        },
+        {
+          "id": "TE0132",
+          "separator": ": ",
+          "name": "Biais de négativité",
+          "description": "Tactique qui exploite la tendance à accorder plus d'attention et de poids aux expériences négatives qu'aux positives.",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui favorise les informations clivantes, étranges ou surprenantes pour capter l’attention de la cible.",
+      "sections": []
+    },
+    {
+      "id": "TA0014",
+      "separator": ": ",
+      "name": "Ecart à la norme",
+      "techniques": [
+        {
+          "id": "TE0141",
+          "separator": ": ",
+          "name": "Effet von Restorff",
+          "description": "L'effet Von Restorff, nommé d'après la psychiatre Hedwig von Restorff, ou effet d'isolation, prévoit qu'un objet qui se détache d'autres, « tel un pouce levé de la main », est plus susceptible d'être retenu. Il engendre ainsi un biais cognitif retenant ce qui est inhabituel, qui s'écarte de la normalité attendue.\nsource: https://fr.wikipedia.org/wiki/Effet_von_Restorff",
+          "sections": []
+        },
+        {
+          "id": "TE0142",
+          "separator": ": ",
+          "name": "Biais d’ancrage",
+          "description": "En psychologie, l’ancrage désigne la difficulté à se départir d'une première impression. C'est un biais de jugement qui pousse à se fier à l'information reçue en premier dans une prise de décision.\nhttps://fr.wikipedia.org/wiki/Ancrage_(psychologie)",
+          "sections": []
+        },
+        {
+          "id": "TE0143",
+          "separator": ": ",
+          "name": "Effet de contraste",
+          "description": "L'effet de contraste est une tactique dans laquelle on va modifier la perception d'un fait en favorisant la comparaison avec un autre précédemment observé. C'est un phénomène psychologique dans lequel la perception d’un objet ou d’une expérience est modifiée en fonction de sa comparaison avec un autre objet ou expérience récemment observé.\nhttps://biais-cognitif.com/biais/effet-de-contraste/",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui propose repose sur la capacité à détecter les changements dans notre environnement",
+      "sections": []
+    },
+    {
+      "id": "TA0015",
+      "separator": ": ",
+      "name": "Détail signifiant",
+      "techniques": [
+        {
+          "id": "TE0151",
+          "separator": ": ",
+          "name": "Biais de distinction",
+          "description": "Technique qui repose sur le fait que nous avons tendance à surévaluer les différences entre deux options lorsque nous les examinons ensemble. Cette technique privilégie donc la proposition d'options à comparer.",
+          "sections": []
+        },
+        {
+          "id": "TE0152",
+          "separator": ": ",
+          "name": "Loi de Weber-Fechner",
+          "description": "Selon cette loi‚ plus l’intensité du stimulus est élevée‚ plus la DJJ (différence juste perceptible) est importante. Autrement dit‚ pour percevoir une différence‚ il faut une variation plus importante de l’intensité du stimulus lorsque celui-ci est déjà intense.\nCette technique va donc adapter l'intensité de l'information au contexte initial. Elle peut en outre être utilisée pour \"noyer le poisson\". En clair en sur exposant les cibles avec un sujet ou une information, vous rendez tout changement plus couteux.",
+          "sections": []
+        },
+        {
+          "id": "TE0153",
+          "separator": ": ",
+          "name": "Clickbait",
+          "description": "Un piège à clics (en anglais clickbait: « appât à clics »), appelé vulgairement une pute à clics, pute-à-clics ou putaclic, est un contenu web destiné exclusivement à attirer le maximum de passages d'internautes afin de générer des revenus publicitaires en ligne. Il a pour but de rapporter de l'argent au créateur de l'article. Pour ce faire, celui-ci s'appuie sur un titre racoleur, voire mensonger, et sur des éléments sensationnels ou émotionnels au détriment de la qualité ou de l'exactitude, basculant éventuellement vers la fausse information[7]. Le piège à clics sert à attirer les clics à peu de frais et à encourager le partage de son contenu sur les réseaux sociaux. [source: wikipédia](https://fr.wikipedia.org/wiki/Pi%C3%A8ge_%C3%A0_clics)",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui exploite la propension d'une cible à détecter un détail et à lui donner du sens",
+      "sections": []
+    }
+  ]
+}

--- a/docs/data/INFORM.json
+++ b/docs/data/INFORM.json
@@ -1,0 +1,136 @@
+{
+  "phase": "INFORM",
+  "tactics": [
+    {
+      "id": "TA0021",
+      "separator": ": ",
+      "name": "Création d’un motif",
+      "techniques": [
+        {
+          "id": "TE0211",
+          "separator": ": ",
+          "name": "biais de corrélation illusoire",
+          "description": "Le biais de corrélation illusoire est un biais cognitif qui consiste à imaginer un lien entre deux évènements ou deux types d'évènements alors qu'il n'y en a pas ou à exagérer ce lien. Autres formulations possibles : biais de fausse corrélation ou biais de corrélation trompeuse.",
+          "sections": []
+        },
+        {
+          "id": "TE0212",
+          "separator": ": ",
+          "name": "Biais de la preuve anecdotique",
+          "description": "Utilisation de preuves anecdotiques pour nourrir un raisonnement. Les preuves anecdotiques sont des preuves tirées d'anecdotes, c'est-à-dire des preuves recueillies de façon occasionnelle ou informelle, s'appuyant fortement ou entièrement sur des témoignages personnels.",
+          "sections": []
+        },
+        {
+          "id": "TE0213",
+          "separator": ": ",
+          "name": "Illusion des séries",
+          "description": "Tendance à percevoir à tort, de fausses séquences ou coïncidences significatives dans des données aléatoires. source : https://biais-cognitif.com/biais/illusion-des-series/",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui permet de mettre en récit une information reçu, de l’intégrer dans un contexte préexistant.",
+      "sections": []
+    },
+    {
+      "id": "TA0022",
+      "separator": ": ",
+      "name": "Généralisation et renforcement de stéréotypes",
+      "techniques": [
+        {
+          "id": "TE0221",
+          "separator": " : ",
+          "name": "Effet de retournement",
+          "description": "Tendance à renforcer ses croyances préexistantes lorsqu'on est confronté à des informations contradictoires, malgré des preuves contraires.",
+          "sections": []
+        },
+        {
+          "id": "TE0222",
+          "separator": " : ",
+          "name": "Biais de confirmation",
+          "description": "Le biais de confirmation, également dénommé biais de confirmation d'hypothèse, est un mécanisme cognitif qui consiste à privilégier les informations confirmant ses idées préconçues ou ses hypothèses, ou à accorder moins de poids aux hypothèses et informations jouant en défaveur de ses conceptions, ce qui se traduit par une réticence à changer d'avis.",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui vise à simplifier une ou des informlations perçues pour les rendre acceptable et/ou intelligible par la cible",
+      "sections": []
+    },
+    {
+      "id": "TA0023",
+      "separator": ": ",
+      "name": "Supériorité familière",
+      "techniques": [
+        {
+          "id": "TE0231",
+          "separator": "-",
+          "name": "Biais d'homogénéité",
+          "description": "Ce biais nous pousse à croire que les individus d’un groupe auquel nous n’appartenons pas sont tous semblables, tandis que nous percevons plus de diversité dans notre propre groupe.",
+          "sections": []
+        },
+        {
+          "id": "TE0232",
+          "separator": " ",
+          "name": "Biais de la route connue",
+          "description": "Tendance à écarter les informations qui s'éloignent de ce que l'on connait par ailleurs.",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui permet de valoriser une informaiton aux yeux de la cible par exploitation des proximités",
+      "sections": []
+    },
+    {
+      "id": "TA0024",
+      "separator": " ",
+      "name": "simplication",
+      "techniques": [
+        {
+          "id": "TE0241",
+          "separator": " ",
+          "name": "Biais de la somme nulle",
+          "description": "Le biais de la somme nulle est un biais cognitif associé à la pensée à somme nulle ; c'est la tendance des gens à juger intuitivement qu'une situation est à somme nulle, même si ce n'est pas le cas. Ce biais favorise les erreurs à somme nulle, les fausses croyances selon lesquelles les situations sont à somme nulle. De telles erreurs peuvent entraîner des mauvais jugements et de mauvaises décisions. (https://fr.wikipedia.org/wiki/Pens%C3%A9e_%C3%A0_somme_nulle)",
+          "sections": []
+        },
+        {
+          "id": "TE0242",
+          "separator": " ",
+          "name": "Biais de normalité",
+          "description": "Le biais de normalité est un biais cognitif qui conduit les individus à sous-estimer, minimiser voire nier la probabilité, la gravité ou la réalité d'un événement inhabituel, extrême ou catastrophique, en supposant que les choses continueront à se dérouler comme d'habitude. Il repose sur l'idée implicite que le futur ressemblera toujours au passé, que les perturbations majeures sont peu probables ou transitoires, ou qu'elles n'arrivent qu'aux autres.",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui simplifie les concepts et favorise les ordres de grandeurs pour faciliter l'acceptabilité d'une informaiton",
+      "sections": []
+    },
+    {
+      "id": "TA0025",
+      "separator": " ",
+      "name": "Auto-référence",
+      "techniques": [
+        {
+          "id": "TE00251",
+          "separator": " ",
+          "name": "Effet de faux consensus",
+          "description": "l'effet de consensus fallacieux, également connu sous le nom de biais de consensus, est un préjugé cognitif omniprésent qui amène les gens à « voir leurs propres choix comportementaux et jugements comme relativement communs et appropriés aux circonstances existantes ».En d'autres termes, ils supposent que leurs qualités personnelles, leurs caractéristiques, leurs croyances et leurs actions sont relativement répandues par la population générale. Ce faux consensus est important car il augmente l'estime de soi (effet de confiance). Elle peut être dérivée d'un désir de se conformer et d'être aimé par d'autres dans un environnement social. [source](https://en.wikipedia.org/wiki/False_consensus_effect)",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui exploite les fait que la cible pense que ses interlocuteurs ont le même niveau de connaissance et partage des références communes.",
+      "sections": []
+    },
+    {
+      "id": "TA0026",
+      "separator": " ",
+      "name": "Projection temporelle",
+      "techniques": [
+        {
+          "id": "TE0261",
+          "separator": " ",
+          "name": "Biais rétrospectif",
+          "description": "### Définition\nLe biais rétrospectif ou déterminisme rampant est la tendance commune des gens à percevoir les événements passés comme ayant été plus prévisibles qu'ils ne l'étaient. Après qu'un événement se soit produit, les gens pensent souvent qu'ils auraient prédit ou peut-être même auraient su avec un degré élevé de certitude ce que le résultat de l'événement aurait été avant que l'événement ne se soit produit. [source](https://en.wikipedia.org/wiki/Hindsight_bias)\n### Illustration\nLe biais rétrospectif est utilisé dans la diffusion de nombreuses théories conspirationistes pour expliquer un événement. Ce biais surestime la présence de signes ou de signaux faibles qui auraient du conduire à une prise de décision. En manipulation de l'information ce biais est utilisé pour favoriser les discours d'analyse de situations post événement en mettant en avant des prétendues signes avant-coureurs. Le narratif repose alors sur des formulations simples qui s'appuient sur des événements réels ou forgés.",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui sappuie sur les souvenirs (réels ou forgés) pour crédibiliser un discours ou une information.",
+      "sections": []
+    }
+  ]
+}

--- a/docs/data/MEMORISE.json
+++ b/docs/data/MEMORISE.json
@@ -1,0 +1,102 @@
+{
+  "phase": "MEMORISE",
+  "tactics": [
+    {
+      "id": "TA0031",
+      "separator": " ",
+      "name": "Renforcement indirect",
+      "techniques": [
+        {
+          "id": "TE0312",
+          "separator": " : ",
+          "name": "biais de confusion de source",
+          "description": "",
+          "sections": []
+        },
+        {
+          "id": "TE0313",
+          "separator": " : ",
+          "name": "effet d'espacement",
+          "description": "",
+          "sections": []
+        },
+        {
+          "id": "TE0314",
+          "separator": " : ",
+          "name": "Effet de suggestion",
+          "description": "",
+          "sections": []
+        },
+        {
+          "id": "TE0315",
+          "separator": " : ",
+          "name": "[Effet de génération](https://en.wikipedia.org/wiki/Generation_effect)",
+          "description": "",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui favorise la mémorisation et la construction de souvenirs par renforcement de sources secondaires",
+      "sections": []
+    },
+    {
+      "id": "TA0032",
+      "separator": " ",
+      "name": "Renforcement pré-existant",
+      "techniques": [
+        {
+          "id": "TE0321",
+          "separator": " : ",
+          "name": "[Stéréotype implicite](https://en.wikipedia.org/wiki/Implicit_stereotype)",
+          "description": "Le stéréotype implicite désigne des associations automatiques et inconscientes entre des groupes sociaux et des traits ou comportements spécifiques. Ces biais influencent nos jugements et interactions, souvent sans que nous en soyons conscients, et peuvent perpétuer des inégalités.",
+          "sections": []
+        },
+        {
+          "id": "TE0322",
+          "separator": " : ",
+          "name": "[Effacement négatif](https://en.wikipedia.org/wiki/Fading_affect_bias)",
+          "description": "",
+          "sections": []
+        },
+        {
+          "id": "TE0122",
+          "separator": " : ",
+          "name": "[Effet de contexte](https://books.openedition.org/editionsmsh/14811)",
+          "description": "",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui favorise la mémorisation d'une information en s'appuyant sur des stéréotypes ou des croyances pré-existantes",
+      "sections": []
+    },
+    {
+      "id": "TA0033",
+      "separator": " ",
+      "name": "Exposition de contenus",
+      "techniques": [
+        {
+          "id": "TE0331",
+          "separator": " : ",
+          "name": "[Effet de récence](https://www.toupie.org/Biais/Effet_recence.htm)",
+          "description": "### Définition\nL’effet de récence est un biais cognitif où les informations les plus récentes reçues par une personne ont un impact disproportionné sur sa mémoire et ses décisions. Cet effet est souvent comparé à l’effet de primauté, qui désigne la mémorisation préférentielle des premières informations. Alors que l’effet de primauté concerne l’ancrage des premières informations dans la mémoire à long terme, l’effet de récence reflète la persistance des dernières informations dans la mémoire à court terme. [source](https://biais-cognitif.com/biais/effet-de-recence/)",
+          "sections": []
+        },
+        {
+          "id": "TE0332",
+          "separator": " : ",
+          "name": "[Effet de simple exposition](https://biais-cognitif.com/biais/effet-de-simple-exposition/)",
+          "description": "### Définition\nL’effet de simple exposition, identifié par le psychologue Robert Zajonc en 1968, se base sur l’idée que la répétition d’exposition à un stimulus augmente notre préférence pour celui-ci. Cette tendance est intrinsèquement liée à notre perception de familiarité et de confort avec ce qui est connu et habituel. Le fondement de ce biais réside dans notre traitement psychologique et émotionnel de la familiarité comme un indicateur de sécurité et de fiabilité.\n\nCe biais peut être brièvement comparé à l’effet de récence (TE0331), où les informations les plus récemment reçues sont les plus influentes. Tandis que l’effet de récence porte sur l’impact des dernières informations sur notre mémoire et notre jugement, l’effet de simple exposition s’attache à la familiarité et à la préférence croissante pour un stimulus à travers des expositions répétées, indépendamment de son contenu ou de sa qualité. [source](https://biais-cognitif.com/biais/effet-de-simple-exposition/)",
+          "sections": []
+        },
+        {
+          "id": "TE0333",
+          "separator": " : ",
+          "name": "[Effet de primaute](https://biais-cognitif.com/biais/effet-de-primaute/)",
+          "description": "### Définition\nL’effet de primauté est un biais cognitif où les premières informations reçues exercent une influence disproportionnée sur la perception et le jugement. Cela peut être comparé, bien que brièvement, à l’effet de récence (TE0331), où les dernières informations présentées ont un impact similaire. L’effet de primauté se distingue par la persistance des premières informations dans la mémoire à long terme, alors que l’effet de récence concerne la mémoire à court terme. [source](https://biais-cognitif.com/biais/effet-de-primaute/)\n### Illustration\nCe phénomène est particulièrement utile pour le traitement de l'actualité. La façon dont un sujet est initialement présenté va durablement orienté la mannière dont il est reçu et traité par le public. Une erreur de communication initiale est très difficilement rattrapée et place l'interlocuteur en \"défensive\" ce qui nuit à la portée de son discours.",
+          "sections": []
+        }
+      ],
+      "description": "Tactique qui favorise la surexposition à une information pour favoriser sa mémorisation",
+      "sections": []
+    }
+  ]
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,502 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DIMA Navigator</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #0c0e13;
+  --surface: #13161d;
+  --surface-2: #1a1e28;
+  --border: #252a36;
+  --border-light: #323848;
+  --text: #e2e6ef;
+  --text-muted: #8a92a6;
+  --text-dim: #5a6178;
+
+  --detect: #e85d3a;
+  --detect-bg: rgba(232,93,58,0.10);
+  --detect-border: rgba(232,93,58,0.35);
+
+  --inform: #4aa8d8;
+  --inform-bg: rgba(74,168,216,0.10);
+  --inform-border: rgba(74,168,216,0.35);
+
+  --memorise: #9b6dd7;
+  --memorise-bg: rgba(155,109,215,0.10);
+  --memorise-border: rgba(155,109,215,0.35);
+
+  --act: #3cc77a;
+  --act-bg: rgba(60,199,122,0.10);
+  --act-border: rgba(60,199,122,0.35);
+
+  --font-mono: 'JetBrains Mono', monospace;
+  --font-body: 'Source Sans 3', sans-serif;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { font-size: 14px; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-body);
+  min-height: 100vh;
+}
+
+a { color: var(--inform); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* HEADER */
+.header {
+  padding: 18px 28px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(12,14,19,0.92);
+  backdrop-filter: blur(10px);
+}
+.logo {
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  background: linear-gradient(135deg, var(--detect), var(--inform), var(--memorise), var(--act));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.logo-sub {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-left: 12px;
+  letter-spacing: 0.05em;
+}
+.header-right { display: flex; align-items: center; gap: 14px; }
+.search-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 14px;
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  width: 280px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.search-box:focus { border-color: var(--text-dim); }
+.search-box::placeholder { color: var(--text-dim); }
+.match-count {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  min-width: 70px;
+}
+
+/* MAIN GRID */
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+  padding: 22px 28px 60px;
+}
+@media (max-width: 1100px) { .matrix { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 640px)  { .matrix { grid-template-columns: 1fr; } }
+
+.column { display: flex; flex-direction: column; gap: 14px; }
+
+.phase-header {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  padding: 10px 14px;
+  border-radius: 6px;
+  border: 1px solid;
+  text-transform: uppercase;
+  position: sticky;
+  top: 78px;
+  z-index: 10;
+  backdrop-filter: blur(8px);
+}
+.column.detect   .phase-header { color: var(--detect);   background: var(--detect-bg);   border-color: var(--detect-border); }
+.column.inform   .phase-header { color: var(--inform);   background: var(--inform-bg);   border-color: var(--inform-border); }
+.column.memorise .phase-header { color: var(--memorise); background: var(--memorise-bg); border-color: var(--memorise-border); }
+.column.act      .phase-header { color: var(--act);      background: var(--act-bg);      border-color: var(--act-border); }
+
+/* TACTIC CARD */
+.tactic {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.column.detect   .tactic { border-left-color: var(--detect); }
+.column.inform   .tactic { border-left-color: var(--inform); }
+.column.memorise .tactic { border-left-color: var(--memorise); }
+.column.act      .tactic { border-left-color: var(--act); }
+
+.tactic-header { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.tactic-id {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+}
+.tactic-name { font-size: 0.95rem; font-weight: 600; color: var(--text); }
+.tactic-desc { font-size: 0.85rem; color: var(--text-muted); line-height: 1.4; }
+
+.techniques { display: flex; flex-direction: column; gap: 4px; margin-top: 4px; }
+.technique {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 7px 10px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.technique:hover { border-color: var(--border-light); background: #1f2330; }
+.technique-id {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.technique-name { color: var(--text); flex: 1; }
+
+.hidden { display: none !important; }
+
+/* DETAIL PANEL */
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  z-index: 100;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.overlay.open { display: flex; }
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  max-width: 720px;
+  width: 100%;
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 22px 26px;
+  position: relative;
+}
+.panel-close {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  width: 28px; height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  line-height: 1;
+}
+.panel-close:hover { color: var(--text); border-color: var(--border-light); }
+
+.panel-meta {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.panel-title { font-size: 1.25rem; font-weight: 600; margin-bottom: 14px; }
+.panel-desc { font-size: 0.95rem; color: var(--text); line-height: 1.55; margin-bottom: 18px; white-space: pre-wrap; }
+
+.section { margin-top: 16px; }
+.section-title {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+.section-text { font-size: 0.9rem; color: var(--text); line-height: 1.5; white-space: pre-wrap; }
+.section-list { list-style: none; padding-left: 0; }
+.section-list li {
+  font-size: 0.9rem;
+  color: var(--text);
+  padding: 4px 0 4px 16px;
+  position: relative;
+  line-height: 1.45;
+}
+.section-list li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: var(--text-dim);
+}
+
+.error {
+  padding: 28px;
+  color: var(--detect);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+.empty {
+  padding: 8px 14px;
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+</style>
+</head>
+<body>
+
+<header class="header">
+  <div>
+    <span class="logo">DIMA</span>
+    <span class="logo-sub">Detect · Inform · Memorise · Act</span>
+  </div>
+  <div class="header-right">
+    <span class="match-count" id="match-count"></span>
+    <input type="search" class="search-box" id="search" placeholder="Rechercher (id, nom, description)…" />
+  </div>
+</header>
+
+<main class="matrix" id="matrix"></main>
+
+<div class="overlay" id="overlay">
+  <div class="panel" id="panel">
+    <button class="panel-close" id="panel-close" aria-label="Fermer">×</button>
+    <div class="panel-meta" id="panel-meta"></div>
+    <h2 class="panel-title" id="panel-title"></h2>
+    <p class="panel-desc" id="panel-desc"></p>
+    <div id="panel-sections"></div>
+  </div>
+</div>
+
+<script>
+const PHASES = [
+  { key: "DETECT",   label: "Detect",   className: "detect"   },
+  { key: "INFORM",   label: "Inform",   className: "inform"   },
+  { key: "MEMORISE", label: "Memorise", className: "memorise" },
+  { key: "ACT",      label: "Act",      className: "act"      },
+];
+
+const matrixEl = document.getElementById("matrix");
+const searchEl = document.getElementById("search");
+const matchCountEl = document.getElementById("match-count");
+const overlay = document.getElementById("overlay");
+const panelMeta = document.getElementById("panel-meta");
+const panelTitle = document.getElementById("panel-title");
+const panelDesc = document.getElementById("panel-desc");
+const panelSections = document.getElementById("panel-sections");
+
+const allTechniques = []; // index aplati pour resoudre un id depuis la barre de recherche
+
+function autoLink(text) {
+  // Markdown-style links [label](url) deja dans le contenu, plus URLs nues
+  const md = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g;
+  let escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  escaped = escaped.replace(md, (_, label, url) =>
+    `<a href="${url}" target="_blank" rel="noopener">${label}</a>`
+  );
+  // URLs nues qui n'etaient pas dans un [..](..)
+  const bare = /(^|[^"'>])(https?:\/\/[^\s<)]+)(?![^<]*<\/a>)/g;
+  escaped = escaped.replace(bare, (_, prefix, url) =>
+    `${prefix}<a href="${url}" target="_blank" rel="noopener">${url}</a>`
+  );
+  return escaped;
+}
+
+function renderSection(sec) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "section";
+  const title = document.createElement("div");
+  title.className = "section-title";
+  title.textContent = sec.title;
+  wrapper.appendChild(title);
+
+  if (sec.text) {
+    const p = document.createElement("div");
+    p.className = "section-text";
+    p.innerHTML = autoLink(sec.text);
+    wrapper.appendChild(p);
+  }
+  if (Array.isArray(sec.items) && sec.items.length) {
+    const ul = document.createElement("ul");
+    ul.className = "section-list";
+    for (const item of sec.items) {
+      const li = document.createElement("li");
+      li.innerHTML = autoLink(item);
+      ul.appendChild(li);
+    }
+    wrapper.appendChild(ul);
+  }
+  return wrapper;
+}
+
+function openPanel(tech, tactic, phase) {
+  panelMeta.textContent = `${phase.label} · ${tactic.id} ${tactic.name}`;
+  panelTitle.textContent = `${tech.id} · ${tech.name}`;
+  panelDesc.innerHTML = tech.description ? autoLink(tech.description) : "";
+  panelSections.innerHTML = "";
+  for (const sec of tech.sections || []) {
+    panelSections.appendChild(renderSection(sec));
+  }
+  overlay.classList.add("open");
+}
+
+function closePanel() { overlay.classList.remove("open"); }
+
+overlay.addEventListener("click", (e) => { if (e.target === overlay) closePanel(); });
+document.getElementById("panel-close").addEventListener("click", closePanel);
+document.addEventListener("keydown", (e) => { if (e.key === "Escape") closePanel(); });
+
+function buildPhaseColumn(phase, data) {
+  const col = document.createElement("section");
+  col.className = `column ${phase.className}`;
+  col.dataset.phase = phase.key;
+
+  const header = document.createElement("div");
+  header.className = "phase-header";
+  const tacCount = data.tactics.length;
+  const techCount = data.tactics.reduce((n, t) => n + (t.techniques?.length || 0), 0);
+  header.textContent = `${phase.label} — ${tacCount} TA · ${techCount} TE`;
+  col.appendChild(header);
+
+  for (const tactic of data.tactics) {
+    const card = document.createElement("article");
+    card.className = "tactic";
+    card.dataset.id = tactic.id;
+    card.dataset.name = (tactic.name || "").toLowerCase();
+    card.dataset.desc = (tactic.description || "").toLowerCase();
+
+    const head = document.createElement("div");
+    head.className = "tactic-header";
+    const idEl = document.createElement("span");
+    idEl.className = "tactic-id";
+    idEl.textContent = tactic.id;
+    const nameEl = document.createElement("span");
+    nameEl.className = "tactic-name";
+    nameEl.textContent = tactic.name;
+    head.append(idEl, nameEl);
+    card.appendChild(head);
+
+    if (tactic.description) {
+      const desc = document.createElement("div");
+      desc.className = "tactic-desc";
+      desc.innerHTML = autoLink(tactic.description);
+      card.appendChild(desc);
+    }
+
+    const techs = document.createElement("div");
+    techs.className = "techniques";
+    if (!tactic.techniques?.length) {
+      const empty = document.createElement("div");
+      empty.className = "empty";
+      empty.textContent = "(aucune technique)";
+      techs.appendChild(empty);
+    }
+    for (const tech of tactic.techniques || []) {
+      const item = document.createElement("div");
+      item.className = "technique";
+      item.dataset.id = tech.id;
+      item.dataset.name = (tech.name || "").toLowerCase();
+      item.dataset.desc = (tech.description || "").toLowerCase();
+
+      const tid = document.createElement("span");
+      tid.className = "technique-id";
+      tid.textContent = tech.id;
+      const tname = document.createElement("span");
+      tname.className = "technique-name";
+      tname.textContent = tech.name;
+      item.append(tid, tname);
+      item.addEventListener("click", () => openPanel(tech, tactic, phase));
+
+      techs.appendChild(item);
+      allTechniques.push({ tech, tactic, phase, el: item });
+    }
+    card.appendChild(techs);
+    col.appendChild(card);
+  }
+
+  return col;
+}
+
+function applyFilter(query) {
+  const q = query.trim().toLowerCase();
+  let visibleTechs = 0;
+  let visibleTacs = 0;
+
+  for (const card of document.querySelectorAll(".tactic")) {
+    const tacMatch = !q ||
+      card.dataset.id.toLowerCase().includes(q) ||
+      card.dataset.name.includes(q) ||
+      card.dataset.desc.includes(q);
+
+    let anyTechVisible = false;
+    for (const item of card.querySelectorAll(".technique")) {
+      const techMatch = !q ||
+        tacMatch ||
+        item.dataset.id.toLowerCase().includes(q) ||
+        item.dataset.name.includes(q) ||
+        item.dataset.desc.includes(q);
+      item.classList.toggle("hidden", !techMatch);
+      if (techMatch) { anyTechVisible = true; visibleTechs += 1; }
+    }
+
+    const showCard = tacMatch || anyTechVisible;
+    card.classList.toggle("hidden", !showCard);
+    if (showCard) visibleTacs += 1;
+  }
+
+  matchCountEl.textContent = q ? `${visibleTacs} TA · ${visibleTechs} TE` : "";
+}
+
+searchEl.addEventListener("input", (e) => applyFilter(e.target.value));
+
+async function load() {
+  try {
+    const results = await Promise.all(
+      PHASES.map((p) =>
+        fetch(`data/${p.key}.json`).then((r) => {
+          if (!r.ok) throw new Error(`${p.key}: HTTP ${r.status}`);
+          return r.json();
+        })
+      )
+    );
+    matrixEl.innerHTML = "";
+    PHASES.forEach((phase, i) => matrixEl.appendChild(buildPhaseColumn(phase, results[i])));
+  } catch (err) {
+    matrixEl.innerHTML = `<div class="error">Erreur de chargement: ${err.message}<br>Servir le dossier <code>docs/</code> via un serveur HTTP (les fetch ne fonctionnent pas en file://).</div>`;
+  }
+}
+
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Ajoute `docs/index.html`, un SPA single-file qui rend la matrice DIMA en 4 colonnes (DETECT/INFORM/MEMORISE/ACT) avec recherche globale et panneau de detail par technique.
- Charge les donnees via `fetch('data/<PHASE>.json')` -- les JSONs sont commites dans `docs/data/` pour fonctionner aussi en local (`python -m http.server` dans `docs/`).
- Ajoute `.github/workflows/pages.yml` qui :
  - Regenere `docs/data/*.json` depuis les `.md` sources via `uv run src/dima_convert.py md2json --all -o docs/data` (le site reflete toujours la derniere version du markdown)
  - Publie `docs/` sur GitHub Pages

## Avant de merger
- Activer GitHub Pages dans les settings du repo : **Settings -> Pages -> Source: GitHub Actions**.

## Test plan
- [ ] Verifier visuellement le SPA en local : `python -m http.server -d docs 8000` puis ouvrir http://localhost:8000
- [ ] Verifier la recherche, le clic sur une technique (ouvre un panneau), la fermeture (Esc/clic-hors)
- [ ] Verifier sur mobile (responsive: 4 cols -> 2 cols -> 1 col)
- [ ] Apres merge, verifier le job Pages dans Actions et l'URL deployee

Generated with [Claude Code](https://claude.com/claude-code)