### PR TITLE
feat(spa): selection de techniques + rapport de campagne PDF

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -577,6 +577,7 @@ a:hover { text-decoration: underline; }
 
     <div class="report-actions">
       <button class="btn" id="report-cancel">Fermer</button>
+      <button class="btn" id="report-json">Exporter JSON</button>
       <button class="btn primary" id="report-print">Imprimer / PDF</button>
     </div>
   </div>
@@ -986,6 +987,57 @@ function buildPrintableReport() {
 
   reportPrintable.innerHTML = parts.join("");
 }
+
+function slugify(s) {
+  return (s || "campagne-dima")
+    .toString()
+    .normalize("NFD").replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60) || "campagne-dima";
+}
+
+function buildCampaignJSON() {
+  const items = allTechniques
+    .filter((t) => selected.has(t.tech.id))
+    .sort((a, b) => a.tech.id.localeCompare(b.tech.id));
+
+  return {
+    title: campaignName || "Rapport DIMA",
+    date: campaignDate,
+    notes: campaignNotes,
+    generated_at: new Date().toISOString(),
+    techniques: items.map(({ tech, tactic, phase }) => ({
+      id: tech.id,
+      name: tech.name,
+      phase: phase.key,
+      tactic_id: tactic.id,
+      tactic_name: tactic.name,
+      description: tech.description || "",
+      sections: tech.sections || [],
+      observation: techNotes[tech.id] || "",
+    })),
+  };
+}
+
+document.getElementById("report-json").addEventListener("click", () => {
+  campaignName  = repName.value;
+  campaignDate  = repDate.value;
+  campaignNotes = repNotes.value;
+  saveSelection();
+
+  const payload = buildCampaignJSON();
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${slugify(payload.title)}.json`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+});
 
 document.getElementById("report-print").addEventListener("click", () => {
   campaignName  = repName.value;

--- a/docs/index.html
+++ b/docs/index.html
@@ -577,9 +577,11 @@ a:hover { text-decoration: underline; }
 
     <div class="report-actions">
       <button class="btn" id="report-cancel">Fermer</button>
+      <button class="btn" id="report-import">Importer JSON</button>
       <button class="btn" id="report-json">Exporter JSON</button>
       <button class="btn primary" id="report-print">Imprimer / PDF</button>
     </div>
+    <input type="file" id="report-import-file" accept="application/json,.json" hidden />
   </div>
 </div>
 
@@ -1020,6 +1022,56 @@ function buildCampaignJSON() {
     })),
   };
 }
+
+const importBtn = document.getElementById("report-import");
+const importFile = document.getElementById("report-import-file");
+
+importBtn.addEventListener("click", () => importFile.click());
+
+importFile.addEventListener("change", async () => {
+  const file = importFile.files?.[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const data = JSON.parse(text);
+    if (!Array.isArray(data.techniques)) {
+      throw new Error("format invalide (techniques[] manquant)");
+    }
+    const knownIds = new Set(allTechniques.map((t) => t.tech.id));
+    const importedIds = data.techniques.map((t) => t.id).filter((id) => knownIds.has(id));
+    const unknown = data.techniques.length - importedIds.length;
+
+    const replace = !selected.size || confirm(
+      `Importer ${importedIds.length} technique(s)${unknown ? ` (${unknown} inconnue(s) ignoree(s))` : ""} ?\nLa selection actuelle sera remplacee.`
+    );
+    if (!replace) { importFile.value = ""; return; }
+
+    selected.clear();
+    Object.keys(techNotes).forEach((k) => delete techNotes[k]);
+    for (const t of data.techniques) {
+      if (!knownIds.has(t.id)) continue;
+      selected.add(t.id);
+      if (t.observation) techNotes[t.id] = t.observation;
+    }
+    campaignName  = data.title || "";
+    campaignDate  = data.date  || "";
+    campaignNotes = data.notes || "";
+
+    // Sync UI: cases a cocher, marqueurs, formulaire
+    for (const t of allTechniques) {
+      const sel = selected.has(t.tech.id);
+      t.check.checked = sel;
+      t.el.classList.toggle("selected", sel);
+    }
+    saveSelection();
+    updateCampaignUI();
+    openReport();
+  } catch (err) {
+    alert(`Import echoue: ${err.message}`);
+  } finally {
+    importFile.value = "";
+  }
+});
 
 document.getElementById("report-json").addEventListener("click", () => {
   campaignName  = repName.value;

--- a/docs/index.html
+++ b/docs/index.html
@@ -268,6 +268,266 @@ a:hover { text-decoration: underline; }
   font-size: 0.85rem;
   font-style: italic;
 }
+
+/* CAMPAIGN SELECTION */
+.tech-check {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--border-light);
+  border-radius: 3px;
+  background: var(--surface);
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: background 0.12s, border-color 0.12s;
+}
+.tech-check:hover { border-color: var(--text-dim); }
+.tech-check:checked {
+  background: var(--inform);
+  border-color: var(--inform);
+}
+.tech-check:checked::after {
+  content: "";
+  position: absolute;
+  left: 3px; top: 0px;
+  width: 5px; height: 9px;
+  border: solid #0c0e13;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+.technique.selected {
+  background: rgba(74,168,216,0.08);
+  border-color: var(--inform-border);
+}
+
+.campaign-chip {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--inform);
+  background: var(--inform-bg);
+  border: 1px solid var(--inform-border);
+  padding: 5px 10px;
+  border-radius: 4px;
+  display: none;
+}
+.campaign-chip.visible { display: inline-block; }
+.btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  padding: 7px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.btn:hover { border-color: var(--text-dim); color: var(--text); }
+.btn.primary { color: var(--inform); border-color: var(--inform-border); }
+.btn.primary:hover { background: var(--inform-bg); }
+.btn[disabled] { opacity: 0.4; cursor: not-allowed; }
+.btn[disabled]:hover { border-color: var(--border); color: var(--text-muted); background: transparent; }
+
+/* REPORT MODAL */
+.report-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  z-index: 110;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.report-overlay.open { display: flex; }
+.report-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  max-width: 820px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 24px 28px;
+  position: relative;
+}
+.report-panel h2 { font-size: 1.2rem; margin-bottom: 16px; }
+.report-panel label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin: 14px 0 6px;
+}
+.report-panel input[type=text],
+.report-panel input[type=date],
+.report-panel textarea {
+  width: 100%;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  padding: 8px 10px;
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  outline: none;
+}
+.report-panel textarea { resize: vertical; min-height: 70px; }
+.report-panel input:focus,
+.report-panel textarea:focus { border-color: var(--text-dim); }
+
+.report-tech-list {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.report-tech {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--inform);
+  border-radius: 4px;
+  padding: 10px 12px;
+}
+.report-tech-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.report-tech-id {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+.report-tech-name { font-weight: 600; flex: 1; }
+.report-tech-remove {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.report-tech-remove:hover { color: var(--detect); border-color: var(--detect-border); }
+
+.report-actions {
+  margin-top: 22px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+/* PRINTABLE REPORT (rendered hidden, revealed when body.printing-report) */
+.report-printable { display: none; }
+
+@media print {
+  body.printing-report .header,
+  body.printing-report .matrix,
+  body.printing-report .overlay,
+  body.printing-report .report-overlay { display: none !important; }
+  body.printing-report .report-printable {
+    display: block;
+    color: #111;
+    background: #fff;
+    font-family: var(--font-body);
+    padding: 0;
+  }
+  body.printing-report a { color: #0a4a8a; text-decoration: underline; }
+  body.printing-report .report-printable h1 {
+    font-size: 22pt;
+    margin-bottom: 4pt;
+    border-bottom: 2pt solid #111;
+    padding-bottom: 6pt;
+  }
+  body.printing-report .report-printable .meta {
+    font-size: 10pt;
+    color: #444;
+    margin-bottom: 14pt;
+  }
+  body.printing-report .report-printable .global-notes {
+    background: #f6f6f6;
+    border-left: 3pt solid #999;
+    padding: 8pt 12pt;
+    margin-bottom: 18pt;
+    font-size: 10.5pt;
+    white-space: pre-wrap;
+  }
+  body.printing-report .report-printable h2 {
+    font-size: 14pt;
+    margin: 16pt 0 6pt;
+    color: #111;
+    border-bottom: 1pt solid #999;
+    padding-bottom: 3pt;
+  }
+  body.printing-report .report-printable .r-tech {
+    page-break-inside: avoid;
+    break-inside: avoid;
+    border: 1pt solid #999;
+    border-left: 3pt solid #1c6a96;
+    padding: 8pt 10pt;
+    margin-bottom: 10pt;
+  }
+  body.printing-report .report-printable .r-tech .r-id {
+    font-family: var(--font-mono);
+    font-size: 9pt;
+    color: #555;
+  }
+  body.printing-report .report-printable .r-tech .r-name {
+    font-size: 12pt;
+    font-weight: 600;
+    margin-bottom: 4pt;
+  }
+  body.printing-report .report-printable .r-tech .r-phase {
+    font-family: var(--font-mono);
+    font-size: 8.5pt;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  body.printing-report .report-printable .r-tech .r-desc {
+    font-size: 10pt;
+    line-height: 1.4;
+    margin: 6pt 0;
+  }
+  body.printing-report .report-printable .r-tech .r-section { margin-top: 6pt; }
+  body.printing-report .report-printable .r-tech .r-section-title {
+    font-family: var(--font-mono);
+    font-size: 8.5pt;
+    color: #444;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  body.printing-report .report-printable .r-tech .r-section li,
+  body.printing-report .report-printable .r-tech .r-section .r-text {
+    font-size: 9.5pt;
+    color: #222;
+    line-height: 1.4;
+  }
+  body.printing-report .report-printable .r-tech .r-obs {
+    margin-top: 8pt;
+    padding: 6pt 10pt;
+    background: #fffbe6;
+    border-left: 3pt solid #d4a900;
+    font-size: 10pt;
+    white-space: pre-wrap;
+  }
+  body.printing-report .report-printable .r-tech .r-obs-label {
+    font-family: var(--font-mono);
+    font-size: 8.5pt;
+    color: #6a5400;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 3pt;
+  }
+  @page { size: A4; margin: 14mm 14mm 16mm; }
+}
 </style>
 </head>
 <body>
@@ -280,6 +540,9 @@ a:hover { text-decoration: underline; }
   <div class="header-right">
     <span class="match-count" id="match-count"></span>
     <input type="search" class="search-box" id="search" placeholder="Rechercher (id, nom, description)…" />
+    <span class="campaign-chip" id="campaign-chip"></span>
+    <button class="btn" id="clear-btn" disabled>Effacer</button>
+    <button class="btn primary" id="report-btn" disabled>Rapport</button>
   </div>
 </header>
 
@@ -294,6 +557,32 @@ a:hover { text-decoration: underline; }
     <div id="panel-sections"></div>
   </div>
 </div>
+
+<div class="report-overlay" id="report-overlay">
+  <div class="report-panel">
+    <button class="panel-close" id="report-close" aria-label="Fermer">×</button>
+    <h2>Rapport de campagne</h2>
+
+    <label for="rep-name">Nom de la campagne</label>
+    <input type="text" id="rep-name" placeholder="ex. Influence pré-électorale 2026" />
+
+    <label for="rep-date">Période d'observation</label>
+    <input type="text" id="rep-date" placeholder="ex. avril–mai 2026" />
+
+    <label for="rep-notes">Contexte général</label>
+    <textarea id="rep-notes" placeholder="Description de la campagne, acteurs, vecteurs, sources…"></textarea>
+
+    <label>Techniques sélectionnées</label>
+    <div class="report-tech-list" id="rep-list"></div>
+
+    <div class="report-actions">
+      <button class="btn" id="report-cancel">Fermer</button>
+      <button class="btn primary" id="report-print">Imprimer / PDF</button>
+    </div>
+  </div>
+</div>
+
+<div class="report-printable" id="report-printable" aria-hidden="true"></div>
 
 <script>
 const PHASES = [
@@ -313,6 +602,39 @@ const panelDesc = document.getElementById("panel-desc");
 const panelSections = document.getElementById("panel-sections");
 
 const allTechniques = []; // index aplati pour resoudre un id depuis la barre de recherche
+
+// CAMPAIGN STATE
+const STORAGE_KEY = "dima.campaign.v1";
+const selected = new Set();
+const techNotes = {};   // techId -> texte d'observation
+let campaignName = "";
+let campaignDate = "";
+let campaignNotes = "";
+
+function loadSelection() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const data = JSON.parse(raw);
+    (data.selected || []).forEach((id) => selected.add(id));
+    Object.assign(techNotes, data.techNotes || {});
+    campaignName  = data.name  || "";
+    campaignDate  = data.date  || "";
+    campaignNotes = data.notes || "";
+  } catch { /* ignore */ }
+}
+function saveSelection() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      selected: [...selected],
+      techNotes,
+      name: campaignName,
+      date: campaignDate,
+      notes: campaignNotes,
+    }));
+  } catch { /* quota / disabled */ }
+}
+loadSelection();
 
 function autoLink(text) {
   // Markdown-style links [label](url) deja dans le contenu, plus URLs nues
@@ -374,7 +696,11 @@ function closePanel() { overlay.classList.remove("open"); }
 
 overlay.addEventListener("click", (e) => { if (e.target === overlay) closePanel(); });
 document.getElementById("panel-close").addEventListener("click", closePanel);
-document.addEventListener("keydown", (e) => { if (e.key === "Escape") closePanel(); });
+document.addEventListener("keydown", (e) => {
+  if (e.key !== "Escape") return;
+  if (reportOverlay.classList.contains("open")) closeReport();
+  else closePanel();
+});
 
 function buildPhaseColumn(phase, data) {
   const col = document.createElement("section");
@@ -428,17 +754,32 @@ function buildPhaseColumn(phase, data) {
       item.dataset.name = (tech.name || "").toLowerCase();
       item.dataset.desc = (tech.description || "").toLowerCase();
 
+      const check = document.createElement("input");
+      check.type = "checkbox";
+      check.className = "tech-check";
+      check.title = "Ajouter à la campagne";
+      check.checked = selected.has(tech.id);
+      check.addEventListener("click", (e) => e.stopPropagation());
+      check.addEventListener("change", () => {
+        if (check.checked) selected.add(tech.id);
+        else selected.delete(tech.id);
+        item.classList.toggle("selected", check.checked);
+        saveSelection();
+        updateCampaignUI();
+      });
+
       const tid = document.createElement("span");
       tid.className = "technique-id";
       tid.textContent = tech.id;
       const tname = document.createElement("span");
       tname.className = "technique-name";
       tname.textContent = tech.name;
-      item.append(tid, tname);
+      item.append(check, tid, tname);
       item.addEventListener("click", () => openPanel(tech, tactic, phase));
+      if (selected.has(tech.id)) item.classList.add("selected");
 
       techs.appendChild(item);
-      allTechniques.push({ tech, tactic, phase, el: item });
+      allTechniques.push({ tech, tactic, phase, el: item, check });
     }
     card.appendChild(techs);
     col.appendChild(card);
@@ -479,6 +820,187 @@ function applyFilter(query) {
 
 searchEl.addEventListener("input", (e) => applyFilter(e.target.value));
 
+// CAMPAIGN UI
+const chipEl = document.getElementById("campaign-chip");
+const clearBtn = document.getElementById("clear-btn");
+const reportBtn = document.getElementById("report-btn");
+const reportOverlay = document.getElementById("report-overlay");
+const repName = document.getElementById("rep-name");
+const repDate = document.getElementById("rep-date");
+const repNotes = document.getElementById("rep-notes");
+const repList = document.getElementById("rep-list");
+const reportPrintable = document.getElementById("report-printable");
+
+function updateCampaignUI() {
+  const n = selected.size;
+  if (n > 0) {
+    chipEl.textContent = `Campagne : ${n} TE`;
+    chipEl.classList.add("visible");
+    clearBtn.disabled = false;
+    reportBtn.disabled = false;
+  } else {
+    chipEl.classList.remove("visible");
+    clearBtn.disabled = true;
+    reportBtn.disabled = true;
+  }
+}
+
+clearBtn.addEventListener("click", () => {
+  if (!selected.size) return;
+  if (!confirm("Effacer la sélection actuelle ?")) return;
+  selected.clear();
+  for (const t of allTechniques) {
+    t.check.checked = false;
+    t.el.classList.remove("selected");
+  }
+  saveSelection();
+  updateCampaignUI();
+});
+
+function openReport() {
+  repName.value  = campaignName;
+  repDate.value  = campaignDate;
+  repNotes.value = campaignNotes;
+  repList.innerHTML = "";
+
+  const items = allTechniques
+    .filter((t) => selected.has(t.tech.id))
+    .sort((a, b) => a.tech.id.localeCompare(b.tech.id));
+
+  for (const { tech, tactic, phase } of items) {
+    const row = document.createElement("div");
+    row.className = "report-tech";
+
+    const head = document.createElement("div");
+    head.className = "report-tech-head";
+
+    const idEl = document.createElement("span");
+    idEl.className = "report-tech-id";
+    idEl.textContent = `${phase.label} · ${tech.id}`;
+
+    const nameEl = document.createElement("span");
+    nameEl.className = "report-tech-name";
+    nameEl.textContent = tech.name;
+
+    const removeBtn = document.createElement("button");
+    removeBtn.className = "report-tech-remove";
+    removeBtn.type = "button";
+    removeBtn.textContent = "Retirer";
+    removeBtn.addEventListener("click", () => {
+      selected.delete(tech.id);
+      delete techNotes[tech.id];
+      const ref = allTechniques.find((t) => t.tech.id === tech.id);
+      if (ref) { ref.check.checked = false; ref.el.classList.remove("selected"); }
+      saveSelection();
+      updateCampaignUI();
+      row.remove();
+      if (!selected.size) closeReport();
+    });
+
+    head.append(idEl, nameEl, removeBtn);
+    row.appendChild(head);
+
+    const obs = document.createElement("textarea");
+    obs.placeholder = "Observation pour cette technique dans la campagne…";
+    obs.value = techNotes[tech.id] || "";
+    obs.addEventListener("input", () => {
+      techNotes[tech.id] = obs.value;
+      saveSelection();
+    });
+    row.appendChild(obs);
+
+    repList.appendChild(row);
+  }
+
+  reportOverlay.classList.add("open");
+}
+
+function closeReport() {
+  campaignName  = repName.value;
+  campaignDate  = repDate.value;
+  campaignNotes = repNotes.value;
+  saveSelection();
+  reportOverlay.classList.remove("open");
+}
+
+reportBtn.addEventListener("click", openReport);
+document.getElementById("report-cancel").addEventListener("click", closeReport);
+document.getElementById("report-close").addEventListener("click", closeReport);
+reportOverlay.addEventListener("click", (e) => { if (e.target === reportOverlay) closeReport(); });
+
+[repName, repDate, repNotes].forEach((el) => {
+  el.addEventListener("input", () => {
+    campaignName  = repName.value;
+    campaignDate  = repDate.value;
+    campaignNotes = repNotes.value;
+    saveSelection();
+  });
+});
+
+function buildPrintableReport() {
+  const items = allTechniques
+    .filter((t) => selected.has(t.tech.id))
+    .sort((a, b) => a.tech.id.localeCompare(b.tech.id));
+
+  const esc = (s) => (s || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const parts = [];
+
+  parts.push(`<h1>${esc(campaignName) || "Rapport DIMA"}</h1>`);
+  const metaBits = [];
+  if (campaignDate) metaBits.push(esc(campaignDate));
+  metaBits.push(`${items.length} technique${items.length > 1 ? "s" : ""}`);
+  metaBits.push(`Généré le ${new Date().toLocaleDateString("fr-FR")}`);
+  parts.push(`<div class="meta">${metaBits.join(" · ")}</div>`);
+
+  if (campaignNotes.trim()) {
+    parts.push(`<div class="global-notes">${esc(campaignNotes)}</div>`);
+  }
+
+  parts.push(`<h2>Techniques observées</h2>`);
+
+  for (const { tech, tactic, phase } of items) {
+    const sectionsHtml = (tech.sections || []).map((sec) => {
+      const itemsHtml = (sec.items || []).length
+        ? `<ul>${sec.items.map((i) => `<li>${autoLink(i)}</li>`).join("")}</ul>`
+        : "";
+      const textHtml = sec.text ? `<div class="r-text">${autoLink(sec.text)}</div>` : "";
+      return `<div class="r-section"><div class="r-section-title">${esc(sec.title)}</div>${textHtml}${itemsHtml}</div>`;
+    }).join("");
+
+    const obs = (techNotes[tech.id] || "").trim();
+    const obsHtml = obs
+      ? `<div class="r-obs"><div class="r-obs-label">Observation</div>${esc(obs)}</div>`
+      : "";
+
+    parts.push(`
+      <div class="r-tech">
+        <div class="r-phase">${esc(phase.label)} · ${esc(tactic.id)} ${esc(tactic.name)}</div>
+        <div class="r-id">${esc(tech.id)}</div>
+        <div class="r-name">${esc(tech.name)}</div>
+        ${tech.description ? `<div class="r-desc">${autoLink(tech.description)}</div>` : ""}
+        ${sectionsHtml}
+        ${obsHtml}
+      </div>
+    `);
+  }
+
+  reportPrintable.innerHTML = parts.join("");
+}
+
+document.getElementById("report-print").addEventListener("click", () => {
+  campaignName  = repName.value;
+  campaignDate  = repDate.value;
+  campaignNotes = repNotes.value;
+  saveSelection();
+  buildPrintableReport();
+  document.body.classList.add("printing-report");
+  window.print();
+});
+
+window.addEventListener("afterprint", () => {
+  document.body.classList.remove("printing-report");
+});
+
 async function load() {
   try {
     const results = await Promise.all(
@@ -491,6 +1013,7 @@ async function load() {
     );
     matrixEl.innerHTML = "";
     PHASES.forEach((phase, i) => matrixEl.appendChild(buildPhaseColumn(phase, results[i])));
+    updateCampaignUI();
   } catch (err) {
     matrixEl.innerHTML = `<div class="error">Erreur de chargement: ${err.message}<br>Servir le dossier <code>docs/</code> via un serveur HTTP (les fetch ne fonctionnent pas en file://).</div>`;
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -302,6 +302,43 @@ a:hover { text-decoration: underline; }
   border-color: var(--inform-border);
 }
 
+.tactic-check {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--border-light);
+  border-radius: 3px;
+  background: var(--surface);
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-left: auto;
+  position: relative;
+  transition: background 0.12s, border-color 0.12s;
+}
+.tactic-check:hover { border-color: var(--text-dim); }
+.tactic-check:checked,
+.tactic-check:indeterminate {
+  background: var(--inform);
+  border-color: var(--inform);
+}
+.tactic-check:checked::after {
+  content: "";
+  position: absolute;
+  left: 4px; top: 1px;
+  width: 5px; height: 9px;
+  border: solid #0c0e13;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+.tactic-check:indeterminate::after {
+  content: "";
+  position: absolute;
+  left: 3px; top: 7px;
+  width: 9px; height: 2px;
+  background: #0c0e13;
+}
+
 .campaign-chip {
   font-family: var(--font-mono);
   font-size: 0.78rem;
@@ -657,6 +694,26 @@ function autoLink(text) {
   return escaped;
 }
 
+function syncTacticCheck(tacticCheck, techChecks) {
+  if (!techChecks.length) {
+    tacticCheck.checked = false;
+    tacticCheck.indeterminate = false;
+    return;
+  }
+  const total = techChecks.length;
+  const checked = techChecks.reduce((n, c) => n + (c.checked ? 1 : 0), 0);
+  tacticCheck.checked = checked === total;
+  tacticCheck.indeterminate = checked > 0 && checked < total;
+}
+
+function syncAllTacticChecks() {
+  for (const card of document.querySelectorAll(".tactic")) {
+    const tac = card.querySelector(".tactic-check");
+    const techs = [...card.querySelectorAll(".tech-check")];
+    if (tac) syncTacticCheck(tac, techs);
+  }
+}
+
 function renderSection(sec) {
   const wrapper = document.createElement("div");
   wrapper.className = "section";
@@ -732,8 +789,14 @@ function buildPhaseColumn(phase, data) {
     const nameEl = document.createElement("span");
     nameEl.className = "tactic-name";
     nameEl.textContent = tactic.name;
-    head.append(idEl, nameEl);
+    const tacticCheck = document.createElement("input");
+    tacticCheck.type = "checkbox";
+    tacticCheck.className = "tactic-check";
+    tacticCheck.title = "Cocher toutes les techniques de cette tactique";
+    head.append(idEl, nameEl, tacticCheck);
     card.appendChild(head);
+
+    const techChecks = [];
 
     if (tactic.description) {
       const desc = document.createElement("div");
@@ -767,6 +830,7 @@ function buildPhaseColumn(phase, data) {
         if (check.checked) selected.add(tech.id);
         else selected.delete(tech.id);
         item.classList.toggle("selected", check.checked);
+        syncTacticCheck(tacticCheck, techChecks);
         saveSelection();
         updateCampaignUI();
       });
@@ -782,10 +846,23 @@ function buildPhaseColumn(phase, data) {
       if (selected.has(tech.id)) item.classList.add("selected");
 
       techs.appendChild(item);
+      techChecks.push(check);
       allTechniques.push({ tech, tactic, phase, el: item, check });
     }
     card.appendChild(techs);
     col.appendChild(card);
+
+    syncTacticCheck(tacticCheck, techChecks);
+    tacticCheck.addEventListener("click", (e) => e.stopPropagation());
+    tacticCheck.addEventListener("change", () => {
+      const target = tacticCheck.checked;
+      for (const c of techChecks) {
+        if (c.checked === target) continue;
+        c.checked = target;
+        c.dispatchEvent(new Event("change"));
+      }
+      syncTacticCheck(tacticCheck, techChecks);
+    });
   }
 
   return col;
@@ -856,6 +933,7 @@ clearBtn.addEventListener("click", () => {
     t.check.checked = false;
     t.el.classList.remove("selected");
   }
+  syncAllTacticChecks();
   saveSelection();
   updateCampaignUI();
 });
@@ -894,6 +972,7 @@ function openReport() {
       delete techNotes[tech.id];
       const ref = allTechniques.find((t) => t.tech.id === tech.id);
       if (ref) { ref.check.checked = false; ref.el.classList.remove("selected"); }
+      syncAllTacticChecks();
       saveSelection();
       updateCampaignUI();
       row.remove();
@@ -1063,6 +1142,7 @@ importFile.addEventListener("change", async () => {
       t.check.checked = sel;
       t.el.classList.toggle("selected", sel);
     }
+    syncAllTacticChecks();
     saveSelection();
     updateCampaignUI();
     openReport();


### PR DESCRIPTION
## Summary
Ajoute la capacite de marquer des techniques observees dans une campagne reelle et de generer un rapport PDF dedie.

## UX
- **Case a cocher** sur chaque technique (clic sur la case = selection, clic ailleurs = ouvre le panneau detail comme avant).
- **Header** : un chip "Campagne : N TE" + boutons "Effacer" et "Rapport" qui s'activent des qu'au moins une technique est cochee.
- **Modal Rapport** :
  - nom de campagne, periode d'observation, contexte general
  - chaque technique selectionnee a son champ "Observation" libre
  - bouton "Imprimer / PDF" -> dialog navigateur (Save as PDF)
- **localStorage** : la selection, les observations et les metadonnees persistent au refresh.
- **Echap** ferme le rapport en priorite, sinon le panneau detail.

## Print stylesheet dedie
Quand l'utilisateur lance l'impression depuis le rapport, `body.printing-report` est ajoute. Le `@media print` correspondant masque la matrice et le header, et affiche un container imprimable propre :
- titre de campagne en h1, metadonnees (date, nb TE, date de generation)
- contexte general dans un encart
- pour chaque technique : phase, ID, nom, description complete, sections (Exemples, References...) **+ l'observation analyste** dans un encart jaune
- A4, marges 14mm, page-break-inside avoid sur chaque technique

## Independant des autres PR
Ce PR ne touche que `docs/index.html` et n'a pas de conflit attendu avec [#40](https://github.com/M82-project/DIMA/pull/40) (qui ajoute l'export PDF de la matrice complete) -- les deux features peuvent coexister.

## Test plan
- [ ] `python -m http.server -d docs 8000`, ouvrir le SPA
- [ ] Cocher quelques techniques dans differentes phases -> verifier le chip et l'activation des boutons
- [ ] Cliquer "Rapport" -> remplir nom, date, notes globales, observations par technique
- [ ] "Imprimer / PDF" -> verifier la prevu d'impression : titre campagne, sections, observations bien presentes
- [ ] Recharger la page -> selection et notes restaurees depuis localStorage
- [ ] "Effacer" -> selection videe apres confirmation

Generated with [Claude Code](https://claude.com/claude-code)